### PR TITLE
Fix version tracking to show correct commit hash

### DIFF
--- a/app/__version__.py
+++ b/app/__version__.py
@@ -1,2 +1,2 @@
-__version__ = "f8d5d38"
-__build_time__ = "2025-09-23T19:13:20Z"
+__version__ = "04cd44e"
+__build_time__ = "2025-09-23T19:56:21Z"


### PR DESCRIPTION
## Problem

The production health endpoint was showing version `f8d5d38` (an older commit) instead of the current commit hash `04cd44e` which contains all the X-Ray fixes.

## Root Cause

The `app/__version__.py` file was generated when we were on commit `f8d5d38` and contained that commit hash. Even though the code was deployed correctly, the version tracking was showing the wrong information.

## Solution

- Regenerated `app/__version__.py` with the correct current commit hash `04cd44e`
- Updated build timestamp to current time
- This will ensure the health endpoint shows the correct version information

## Verification

After this is merged and deployed, the production health endpoint should show:
- `version: "04cd44e"` (the commit with X-Ray fixes)
- Current build timestamp

This will help us verify that the X-Ray tracing fixes are actually deployed.