### PR TITLE
Add transparency option to badge endpoint

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -6,6 +6,9 @@ API dependencies for authentication and database access.
 
 from typing import Optional
 
+# from app.schemas.user import TokenData
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
 from app.core.security import auth0_validator, extract_scopes
@@ -19,10 +22,6 @@ from app.crud.user import (
 )
 from app.db.database import get_db
 from app.models.user import User
-
-# from app.schemas.user import TokenData
-from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 security = HTTPBearer(auto_error=False)
 

--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -2,8 +2,9 @@
 API v1 router that includes all endpoint routers.
 """
 
-from app.api.v1.endpoints import auth, debug, tlog, trig, user, username_analysis
 from fastapi import APIRouter
+
+from app.api.v1.endpoints import auth, debug, tlog, trig, user, username_analysis
 
 api_router = APIRouter()
 

--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -4,6 +4,8 @@ Authentication endpoints.
 
 from datetime import datetime, timezone  # noqa: F401
 
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
@@ -13,8 +15,6 @@ from app.crud.user import (
 )
 from app.schemas.user import UserResponse
 from app.services.auth0_service import auth0_service
-from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordRequestForm
 
 router = APIRouter()
 

--- a/app/api/v1/endpoints/debug.py
+++ b/app/api/v1/endpoints/debug.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPBearer
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
@@ -7,8 +9,6 @@ from app.core.config import settings
 from app.core.security import auth0_validator, extract_scopes
 from app.crud.user import get_user_by_auth0_id, get_user_by_email, get_user_by_name
 from app.schemas.user import Auth0UserInfo
-from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.security import HTTPBearer
 
 router = APIRouter()
 security = HTTPBearer(auto_error=False)

--- a/app/api/v1/endpoints/trig.py
+++ b/app/api/v1/endpoints/trig.py
@@ -5,6 +5,7 @@ Trig endpoints for trigpoint data.
 from math import cos, radians, sqrt
 from typing import Optional
 
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
@@ -20,7 +21,6 @@ from app.schemas.trig import TrigStats as TrigStatsSchema
 from app.schemas.trig import (
     TrigWithIncludes,
 )
-from fastapi import APIRouter, Depends, HTTPException, Query
 
 router = APIRouter()
 

--- a/app/api/v1/endpoints/username_analysis.py
+++ b/app/api/v1/endpoints/username_analysis.py
@@ -4,6 +4,7 @@ Username analysis endpoints for checking duplicate sanitized usernames.
 
 from typing import Any, Dict
 
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_scopes
@@ -17,7 +18,6 @@ from app.crud.user import (
 )
 from app.models.user import User
 from app.utils.username_sanitizer import find_duplicate_sanitized_usernames
-from fastapi import APIRouter, Depends, HTTPException, status
 
 router = APIRouter()
 

--- a/app/core/xray_middleware.py
+++ b/app/core/xray_middleware.py
@@ -6,10 +6,10 @@ import logging
 import time
 from typing import Callable, Optional
 
+from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.core.config import settings
-from fastapi import Request, Response
 
 logger = logging.getLogger(__name__)
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,13 +4,14 @@ Main FastAPI application entry point.
 
 import logging
 
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import HTTPBearer
+
 from app.api.v1.api import api_router
 from app.core.config import settings
 from app.core.logging import setup_logging
 from app.core.tracing import setup_xray_tracing
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.security import HTTPBearer
 
 logger = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,9 @@ requests==2.32.5
 boto3==1.40.25
 types-requests==2.32.4.20250809
 
+# Image generation
+Pillow==11.1.0
+
 # AWS X-Ray and OpenTelemetry tracing
 opentelemetry-api==1.37.0
 opentelemetry-sdk==1.37.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Test configuration and fixtures.
 import warnings
 
 import pytest
+from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -13,7 +14,6 @@ from sqlalchemy.pool import StaticPool
 from app.db.database import Base, get_db
 from app.main import app
 from app.models.user import TLog, User
-from fastapi.testclient import TestClient
 
 # from app.core.security import create_access_token  # Legacy JWT removed
 

--- a/tests/test_api_deps.py
+++ b/tests/test_api_deps.py
@@ -2,9 +2,10 @@
 Target coverage for app/api/deps.py require_scopes branches.
 """
 
-from app.api.deps import require_scopes
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.testclient import TestClient
+
+from app.api.deps import require_scopes
 
 
 def _build_app():

--- a/tests/test_api_router.py
+++ b/tests/test_api_router.py
@@ -2,8 +2,9 @@
 Tests for API router configuration.
 """
 
-from app.core.config import settings
 from fastapi.testclient import TestClient
+
+from app.core.config import settings
 
 
 def test_username_analysis_router_included(client: TestClient):

--- a/tests/test_auth0_username_mapping.py
+++ b/tests/test_auth0_username_mapping.py
@@ -5,12 +5,12 @@ Tests for Auth0 user ID mapping behaviour. Auth0 usernames are no longer support
 import crypt
 from unittest.mock import ANY, patch
 
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.crud.user import update_user_auth0_mapping
 from app.models.user import User
-from fastapi.testclient import TestClient
 
 
 def _make_user(

--- a/tests/test_core_xray_middleware.py
+++ b/tests/test_core_xray_middleware.py
@@ -2,8 +2,9 @@
 Tests for app.core.xray_middleware add_xray_headers utility.
 """
 
-from app.core.xray_middleware import add_xray_headers
 from fastapi import Response
+
+from app.core.xray_middleware import add_xray_headers
 
 
 def test_add_xray_headers_disabled(monkeypatch):

--- a/tests/test_debug_auth0_endpoint.py
+++ b/tests/test_debug_auth0_endpoint.py
@@ -2,8 +2,9 @@
 Coverage tests for /v1/debug/auth0 endpoint branches.
 """
 
-from app.core.config import settings
 from fastapi.testclient import TestClient
+
+from app.core.config import settings
 
 
 def test_debug_auth0_requires_auth(client: TestClient):

--- a/tests/test_deps_require_scopes.py
+++ b/tests/test_deps_require_scopes.py
@@ -4,11 +4,11 @@ Tests to cover require_scopes helper dependency.
 
 # from datetime import timedelta  # Legacy JWT removed
 
-from app.api.deps import require_scopes
-
 # from app.core.security import create_access_token  # Legacy JWT removed
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.testclient import TestClient
+
+from app.api.deps import require_scopes
 
 
 def _build_app():

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -2,8 +2,9 @@
 Tests for lifecycle helper headers and OpenAPI extras.
 """
 
-from app.api.lifecycle import lifecycle, openapi_lifecycle
 from fastapi import APIRouter, FastAPI
+
+from app.api.lifecycle import lifecycle, openapi_lifecycle
 
 
 def _build_app():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,10 +2,10 @@
 Tests for main application endpoints.
 """
 
-from app.core.config import settings
-
 # import pytest  # Currently unused
 from fastapi.testclient import TestClient
+
+from app.core.config import settings
 
 
 def test_health_check(client: TestClient):

--- a/tests/test_main_debug.py
+++ b/tests/test_main_debug.py
@@ -4,10 +4,10 @@ Tests for main application debug endpoints.
 
 from unittest.mock import patch
 
-from app.core.config import settings
-
 # from app.core.security import create_access_token  # Legacy JWT removed
 from fastapi.testclient import TestClient
+
+from app.core.config import settings
 
 
 def test_debug_auth_removed(client: TestClient):

--- a/tests/test_openapi_config.py
+++ b/tests/test_openapi_config.py
@@ -2,8 +2,9 @@
 Tests for custom OpenAPI configuration.
 """
 
-from app.core.config import settings
 from fastapi.testclient import TestClient
+
+from app.core.config import settings
 
 
 def test_openapi_schema_has_security_schemes(client: TestClient):

--- a/tests/test_tlog.py
+++ b/tests/test_tlog.py
@@ -2,10 +2,10 @@
 Tests for tlog endpoints.
 """
 
-from app.core.config import settings
-
 # import pytest  # Currently unused
 from fastapi.testclient import TestClient
+
+from app.core.config import settings
 
 
 def test_get_trig_count_success(client: TestClient, test_tlog_entries):

--- a/tests/test_trig.py
+++ b/tests/test_trig.py
@@ -5,12 +5,12 @@ Tests for trig endpoints.
 from datetime import date, time
 from decimal import Decimal
 
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.models.trig import Trig
 from app.models.trigstats import TrigStats
-from fastapi.testclient import TestClient
 
 
 def test_get_trig_success_minimal(client: TestClient, db: Session):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -2,11 +2,11 @@
 Tests for user endpoints.
 """
 
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.models.user import User
-from fastapi.testclient import TestClient
 
 
 def test_get_user_not_found(client: TestClient, db: Session):

--- a/tests/test_user_badge.py
+++ b/tests/test_user_badge.py
@@ -1,0 +1,131 @@
+"""
+Tests for user badge endpoint.
+"""
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.crud.user import TLog
+from app.models.user import User
+
+
+def test_get_user_badge_not_found(client: TestClient, db: Session):
+    """Test getting a badge for non-existent user returns 404."""
+    response = client.get(f"{settings.API_V1_STR}/users/99999/badge")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "User not found"
+
+
+def test_get_user_badge_success(client: TestClient, db: Session):
+    """Test getting a badge for an existing user."""
+    # Create a test user
+    user = User(
+        id=1,
+        name="testuser",
+        firstname="Test",
+        surname="User",
+        email="test@example.com",
+        cryptpw="$1$test$hash",
+        about="Test user bio",
+        email_valid="Y",
+        public_ind="Y",
+    )
+    db.add(user)
+
+    # Add some test logs for the user
+    log1 = TLog(id=1, user_id=1, trig_id=1, logged="2023-01-01", status=1)
+    log2 = TLog(id=2, user_id=1, trig_id=2, logged="2023-01-02", status=1)
+    log3 = TLog(
+        id=3, user_id=1, trig_id=1, logged="2023-01-03", status=2
+    )  # Same trig, different status
+
+    db.add(log1)
+    db.add(log2)
+    db.add(log3)
+    db.commit()
+
+    response = client.get(f"{settings.API_V1_STR}/users/1/badge")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert "user_1_badge.png" in response.headers.get("content-disposition", "")
+
+    # Verify we got PNG data
+    assert response.content.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_get_user_badge_transparent(client: TestClient, db: Session):
+    """Test getting a badge with transparent background."""
+    # Create a test user
+    user = User(
+        id=2,
+        name="transparentuser",
+        firstname="Transparent",
+        surname="User",
+        email="transparent@example.com",
+        cryptpw="$1$test$hash",
+        about="Transparent badge user",
+        email_valid="Y",
+        public_ind="Y",
+    )
+    db.add(user)
+    db.commit()
+
+    response = client.get(f"{settings.API_V1_STR}/users/2/badge?transparent=true")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert "user_2_badge.png" in response.headers.get("content-disposition", "")
+
+    # Verify we got PNG data
+    assert response.content.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_get_user_badge_transparent_false(client: TestClient, db: Session):
+    """Test getting a badge with explicit transparent=false."""
+    # Create a test user
+    user = User(
+        id=3,
+        name="opaqueuser",
+        firstname="Opaque",
+        surname="User",
+        email="opaque@example.com",
+        cryptpw="$1$test$hash",
+        about="Opaque badge user",
+        email_valid="Y",
+        public_ind="Y",
+    )
+    db.add(user)
+    db.commit()
+
+    response = client.get(f"{settings.API_V1_STR}/users/3/badge?transparent=false")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert "user_3_badge.png" in response.headers.get("content-disposition", "")
+
+    # Verify we got PNG data
+    assert response.content.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_get_user_badge_no_logs(client: TestClient, db: Session):
+    """Test getting a badge for user with no logs."""
+    # Create a test user with no logs
+    user = User(
+        id=4,
+        name="nologsuser",
+        firstname="NoLogs",
+        surname="User",
+        email="nologs@example.com",
+        cryptpw="$1$test$hash",
+        about="User with no logs",
+        email_valid="Y",
+        public_ind="Y",
+    )
+    db.add(user)
+    db.commit()
+
+    response = client.get(f"{settings.API_V1_STR}/users/4/badge")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+
+    # Verify we got PNG data
+    assert response.content.startswith(b"\x89PNG\r\n\x1a\n")

--- a/tests/test_user_endpoint_envelope.py
+++ b/tests/test_user_endpoint_envelope.py
@@ -2,8 +2,9 @@
 Small coverage bump for user endpoint include parsing branches.
 """
 
-from app.core.config import settings
 from fastapi.testclient import TestClient
+
+from app.core.config import settings
 
 
 def test_get_user_bad_include(client: TestClient, monkeypatch):


### PR DESCRIPTION
Add `/v1/users/{id}/badge` endpoint with a `transparent` parameter to generate user badges with optional transparent backgrounds.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6c8b971-96c8-4d99-8264-09e8e9099b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6c8b971-96c8-4d99-8264-09e8e9099b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

