### PR TITLE
fix: nginx configuration for /app/assets/ serving

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -46,22 +46,22 @@ server {
     # This handles cases where Vite built with base=/app/
     location /app/ {
         alias /usr/share/nginx/html/;
-        try_files $uri $uri/ /index.html;
-
-        # Cache static assets under /app/assets/
-        location ~ ^/app/assets/ {
-            alias /usr/share/nginx/html/assets/;
-            expires 1y;
-            add_header Cache-Control "public, immutable";
-        }
+        try_files $uri $uri/ /app/index.html;
 
         # Don't cache index.html
-        location = /app/ {
-            alias /usr/share/nginx/html/;
-            try_files /index.html =404;
+        location = /app/index.html {
+            alias /usr/share/nginx/html/index.html;
             add_header Cache-Control "no-cache, no-store, must-revalidate";
             add_header Pragma "no-cache";
             add_header Expires "0";
         }
+    }
+
+    # Cache static assets under /app/assets/ - separate location for better matching
+    location ~ ^/app/assets/.+\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        alias /usr/share/nginx/html/;
+        rewrite ^/app/(.*)$ /$1 break;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
     }
 }


### PR DESCRIPTION
- Separated /app/assets/ location block to avoid nested alias issues
- Added explicit file extension matching for static assets
- Fixed try_files to use /app/index.html for SPA routing
- Removed problematic nested location blocks that caused 403 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes SPA to /app/index.html and serves /app/assets/* via a separate, cached location with explicit extension matching.
> 
> - **Nginx config (`web/nginx.conf`)**:
>   - **SPA under `'/app'`**:
>     - Change `try_files` to use `/app/index.html`.
>     - Replace nested `location = /app/` with explicit `location = /app/index.html` and no-cache headers.
>   - **Static assets `'/app/assets/*'`**:
>     - Move to a separate top-level regex `location` with explicit extension matching.
>     - Use `alias /usr/share/nginx/html/` with `rewrite ^/app/(.*)$ /$1 break` for correct path resolution.
>     - Enable long-term caching with `Cache-Control: public, immutable` and `expires 1y`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a344429d339fc599aaf31a78722f9d52ff4dd2f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->