### PR TITLE
fix: nginx location order and try_files for /app/assets

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -42,11 +42,20 @@ server {
         }
     }
 
+    # Cache static assets under /app/assets/ - MUST come before /app/ location
+    location ~ ^/app/assets/.+\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        root /usr/share/nginx/html;
+        rewrite ^/app/(.*)$ /$1 break;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
     # /app prefix - serve the SPA (for production where app is at /app/)
     # This handles cases where Vite built with base=/app/
     location /app/ {
         alias /usr/share/nginx/html/;
-        try_files $uri $uri/ /app/index.html;
+        try_files $uri /app/index.html;
 
         # Don't cache index.html
         location = /app/index.html {
@@ -55,13 +64,5 @@ server {
             add_header Pragma "no-cache";
             add_header Expires "0";
         }
-    }
-
-    # Cache static assets under /app/assets/ - separate location for better matching
-    location ~ ^/app/assets/.+\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-        alias /usr/share/nginx/html/;
-        rewrite ^/app/(.*)$ /$1 break;
-        expires 1y;
-        add_header Cache-Control "public, immutable";
     }
 }


### PR DESCRIPTION
- Moved assets location block before /app/ to ensure regex matches first
- Changed alias to root for simpler path resolution
- Removed $uri/ from try_files to prevent trailing slash redirects
- Added explicit try_files with =404 for assets
- Fixes 301 redirects adding trailing slashes to asset URLs