### PR TITLE
fix: return proper photo URLs after image rotation

### DIFF
--- a/api/api/v1/endpoints/logs.py
+++ b/api/api/v1/endpoints/logs.py
@@ -191,26 +191,31 @@ def get_log(
             )
         if "photos" in tokens:
             photos = tphoto_crud.list_all_photos_for_log(db, log_id=int(log.id))
-            photos_out = [
-                TPhotoResponse(
-                    id=int(p.id),
-                    log_id=int(p.tlog_id),
-                    user_id=int(log.user_id),
-                    type=str(p.type) if p.type and p.type.strip() else "O",
-                    filesize=int(p.filesize),
-                    height=int(p.height),
-                    width=int(p.width),
-                    icon_filesize=int(p.icon_filesize),
-                    icon_height=int(p.icon_height),
-                    icon_width=int(p.icon_width),
-                    name=str(p.name),
-                    text_desc=str(p.text_desc),
-                    public_ind=str(p.public_ind),
-                    photo_url="",
-                    icon_url="",
+            photos_out = []
+            for p in photos:
+                server: Server | None = (
+                    db.query(Server).filter(Server.id == p.server_id).first()
                 )
-                for p in photos
-            ]
+                base_url = str(server.url) if server and server.url else ""
+                photos_out.append(
+                    TPhotoResponse(
+                        id=int(p.id),
+                        log_id=int(p.tlog_id),
+                        user_id=int(log.user_id),
+                        type=str(p.type) if p.type and p.type.strip() else "O",
+                        filesize=int(p.filesize),
+                        height=int(p.height),
+                        width=int(p.width),
+                        icon_filesize=int(p.icon_filesize),
+                        icon_height=int(p.icon_height),
+                        icon_width=int(p.icon_width),
+                        name=str(p.name),
+                        text_desc=str(p.text_desc),
+                        public_ind=str(p.public_ind),
+                        photo_url=join_url(base_url, str(p.filename)),
+                        icon_url=join_url(base_url, str(p.icon_filename)),
+                    )
+                )
 
     return TLogWithIncludes(**base, photos=photos_out)
 

--- a/api/tests/test_logs_photo_urls.py
+++ b/api/tests/test_logs_photo_urls.py
@@ -1,0 +1,187 @@
+"""
+Tests for log photo URLs after rotation.
+"""
+
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from api.core.config import settings
+from api.models.server import Server
+from api.models.tphoto import TPhoto
+from api.models.user import TLog, User
+
+
+def seed_test_data(db: Session) -> tuple[User, TLog, TPhoto]:
+    """Create test user, log, and rotated photo."""
+    user = User(
+        id=401,
+        name="testuser",
+        firstname="Test",
+        surname="User",
+        email="test@example.com",
+        auth0_user_id="auth0|401",
+    )
+    tlog = TLog(
+        id=4001,
+        trig_id=1,
+        user_id=401,
+        date=datetime(2023, 1, 1).date(),
+        time=datetime(2023, 1, 1).time(),
+        osgb_eastings=1,
+        osgb_northings=1,
+        osgb_gridref="AA 00000 00000",
+        fb_number="",
+        condition="G",
+        comment="Test log",
+        score=0,
+        ip_addr="127.0.0.1",
+        source="W",
+    )
+    # Create a photo with rotated filenames
+    photo = TPhoto(
+        id=6001,
+        tlog_id=4001,
+        server_id=settings.PHOTOS_SERVER_ID,
+        type="T",
+        filename="424/P424363_r1.jpg",  # Rotated filename
+        filesize=42953,
+        height=738,
+        width=415,
+        icon_filename="424/I424363_r1.jpg",  # Rotated icon filename
+        icon_filesize=2227,
+        icon_height=120,
+        icon_width=67,
+        name="Test Photo",
+        text_desc="Test description",
+        ip_addr="127.0.0.1",
+        public_ind="Y",
+        deleted_ind="N",
+        source="R",  # R for revised/rotated
+        crt_timestamp=datetime.utcnow(),
+    )
+    db.add(user)
+    db.add(tlog)
+    db.add(photo)
+    db.commit()
+    db.refresh(user)
+    db.refresh(tlog)
+    db.refresh(photo)
+    return user, tlog, photo
+
+
+class TestLogPhotoUrls:
+    """Test that log endpoints properly return photo URLs after rotation."""
+
+    def test_get_log_with_rotated_photo_urls(self, client: TestClient, db: Session):
+        """Test that GET /logs/{log_id}?include=photos returns proper URLs for rotated photos."""
+        user, tlog, photo = seed_test_data(db)
+
+        # Get the server URL for comparison
+        server: Server | None = (
+            db.query(Server).filter(Server.id == settings.PHOTOS_SERVER_ID).first()
+        )
+        base_url = str(server.url) if server and server.url else ""
+
+        # Request log with photos included
+        resp = client.get(f"{settings.API_V1_STR}/logs/{tlog.id}?include=photos")
+
+        assert resp.status_code == 200
+        body = resp.json()
+
+        # Verify photos are included
+        assert "photos" in body
+        assert len(body["photos"]) == 1
+
+        photo_data = body["photos"][0]
+
+        # Verify photo URLs are not empty
+        assert photo_data["photo_url"] != ""
+        assert photo_data["icon_url"] != ""
+
+        # Verify URLs contain the rotated filenames
+        assert "424/P424363_r1.jpg" in photo_data["photo_url"]
+        assert "424/I424363_r1.jpg" in photo_data["icon_url"]
+
+        # Verify full URLs are properly constructed
+        expected_photo_url = (
+            f"{base_url}424/P424363_r1.jpg"
+            if not base_url.endswith("/")
+            else f"{base_url}424/P424363_r1.jpg"
+        )
+        expected_icon_url = (
+            f"{base_url}424/I424363_r1.jpg"
+            if not base_url.endswith("/")
+            else f"{base_url}424/I424363_r1.jpg"
+        )
+
+        # The URLs should match the expected format
+        assert (
+            photo_data["photo_url"] == expected_photo_url
+            or photo_data["photo_url"] == f"{base_url.rstrip('/')}/424/P424363_r1.jpg"
+        )
+        assert (
+            photo_data["icon_url"] == expected_icon_url
+            or photo_data["icon_url"] == f"{base_url.rstrip('/')}/424/I424363_r1.jpg"
+        )
+
+    def test_list_logs_with_rotated_photo_urls(self, client: TestClient, db: Session):
+        """Test that GET /logs?include=photos returns proper URLs for rotated photos."""
+        user, tlog, photo = seed_test_data(db)
+
+        # Request logs with photos included
+        resp = client.get(f"{settings.API_V1_STR}/logs?include=photos")
+
+        assert resp.status_code == 200
+        body = resp.json()
+
+        # Find our test log
+        test_logs = [item for item in body["items"] if item["id"] == tlog.id]
+        assert len(test_logs) == 1
+
+        test_log = test_logs[0]
+
+        # Verify photos are included
+        assert "photos" in test_log
+        assert len(test_log["photos"]) >= 1
+
+        # Find our test photo
+        test_photos = [p for p in test_log["photos"] if p["id"] == photo.id]
+        assert len(test_photos) == 1
+
+        photo_data = test_photos[0]
+
+        # Verify photo URLs are not empty
+        assert photo_data["photo_url"] != ""
+        assert photo_data["icon_url"] != ""
+
+        # Verify URLs contain the rotated filenames
+        assert "424/P424363_r1.jpg" in photo_data["photo_url"]
+        assert "424/I424363_r1.jpg" in photo_data["icon_url"]
+
+    def test_list_photos_for_log_with_rotated_urls(
+        self, client: TestClient, db: Session
+    ):
+        """Test that GET /logs/{log_id}/photos returns proper URLs for rotated photos."""
+        user, tlog, photo = seed_test_data(db)
+
+        # Request photos for the log
+        resp = client.get(f"{settings.API_V1_STR}/logs/{tlog.id}/photos")
+
+        assert resp.status_code == 200
+        body = resp.json()
+
+        # Find our test photo
+        test_photos = [p for p in body["items"] if p["id"] == photo.id]
+        assert len(test_photos) == 1
+
+        photo_data = test_photos[0]
+
+        # Verify photo URLs are not empty
+        assert photo_data["photo_url"] != ""
+        assert photo_data["icon_url"] != ""
+
+        # Verify URLs contain the rotated filenames
+        assert "424/P424363_r1.jpg" in photo_data["photo_url"]
+        assert "424/I424363_r1.jpg" in photo_data["icon_url"]

--- a/docs/bugfixes/photo-url-empty-after-rotation.md
+++ b/docs/bugfixes/photo-url-empty-after-rotation.md
@@ -1,0 +1,79 @@
+# Fix: Photo URLs Empty After Image Rotation
+
+## Problem
+
+After rotating images, the API was returning blank values for `photo_url` and `icon_url` fields in photo responses, even though the database contained correct filenames like `424/P424363_r1.jpg` and `424/I424363_r1.jpg`.
+
+## Root Cause
+
+In `api/api/v1/endpoints/logs.py`, the `get_log()` endpoint (lines 209-210) was **hardcoding empty strings** for `photo_url` and `icon_url` when including photos in the response:
+
+```python
+# BEFORE (BROKEN):
+photos_out = [
+    TPhotoResponse(
+        # ... other fields ...
+        photo_url="",      # ❌ Hardcoded empty string
+        icon_url="",       # ❌ Hardcoded empty string
+    )
+    for p in photos
+]
+```
+
+This was inconsistent with other endpoints in the codebase, which properly constructed URLs using the `join_url()` utility function to combine the server's base URL with the photo filename.
+
+## Solution
+
+Modified `api/api/v1/endpoints/logs.py` to properly construct photo URLs using the same pattern as other endpoints:
+
+```python
+# AFTER (FIXED):
+photos_out = []
+for p in photos:
+    server: Server | None = (
+        db.query(Server).filter(Server.id == p.server_id).first()
+    )
+    base_url = str(server.url) if server and server.url else ""
+    photos_out.append(
+        TPhotoResponse(
+            # ... other fields ...
+            photo_url=join_url(base_url, str(p.filename)),  # ✅ Properly constructed
+            icon_url=join_url(base_url, str(p.icon_filename)),  # ✅ Properly constructed
+        )
+    )
+```
+
+## Files Changed
+
+- `api/api/v1/endpoints/logs.py`: Fixed `get_log()` endpoint to properly construct photo URLs
+- `api/tests/test_logs_photo_urls.py`: Added comprehensive tests to verify photo URLs are correctly returned after rotation
+
+## Testing
+
+All tests pass:
+- ✅ `test_photo_rotate.py`: 14 tests for rotation functionality
+- ✅ `test_logs_include_photos.py`: 4 tests for logs with photos
+- ✅ `test_trig_logs_include_photos.py`: 2 tests for trig logs with photos  
+- ✅ `test_logs_photo_urls.py`: 3 new tests specifically for rotated photo URLs
+
+## Impact
+
+- **GET /v1/logs/{log_id}?include=photos**: Now properly returns photo URLs for rotated images
+- **GET /v1/logs?include=photos**: Already worked correctly (was not affected)
+- **GET /v1/logs/{log_id}/photos**: Already worked correctly (was not affected)
+- **GET /v1/trigs/{trig_id}/logs?include=photos**: Already worked correctly (was not affected)
+- **GET /v1/photos/{photo_id}**: Already worked correctly (was not affected)
+
+## Related Endpoints
+
+The following endpoints were already working correctly and were used as reference for the fix:
+- `list_logs()` in `logs.py` (lines 126-127)
+- `list_photos_for_log()` in `logs.py` (lines 371-372)
+- `list_logs_for_trig()` in `trigs.py` (lines 397-398)
+- `list_photos()` in `photos.py` (lines 85-86)
+- `get_photo()` in `photos.py` (lines 346-347)
+
+## Note
+
+This issue was introduced when the `get_log()` endpoint was implemented with hardcoded empty strings, likely as a placeholder that was never completed. The rotation feature itself was working correctly - it was only the URL display in this specific endpoint that was broken.
+


### PR DESCRIPTION
The get_log() endpoint was returning empty strings for photo_url and icon_url fields when including photos, even though the database contained correct rotated filenames (e.g. 424/P424363_r1.jpg).

This commit fixes the issue by properly constructing URLs using the join_url() utility function to combine the server base URL with the photo filename, matching the pattern used by other endpoints.

- Modified api/api/v1/endpoints/logs.py to construct photo URLs properly
- Added comprehensive tests in api/tests/test_logs_photo_urls.py
- Added documentation in docs/bugfixes/photo-url-empty-after-rotation.md

All 23 related tests pass, including rotation tests and photo URL tests.