### PR TITLE
fix: update GitHub Actions to use Node.js 24 for web pipeline

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'npm'
         cache-dependency-path: web/package-lock.json
 


### PR DESCRIPTION
The web application now requires Node.js 24 (as specified in package.json engines field) due to recent dependency upgrades (vite 7, eslint 9).

Updated web-build.yml workflow to use node-version: '24' instead of '20' to match the local development and Docker build environments.

This fixes the CI/CD pipeline failures.