### PR TITLE
feat(web): enhance preferences and logging UX with defaults and icons

### DIFF
--- a/web/src/components/forms/ConditionSelector.tsx
+++ b/web/src/components/forms/ConditionSelector.tsx
@@ -4,23 +4,24 @@ import Badge from "../ui/Badge";
 interface ConditionOption {
   value: string;
   label: string;
+  icon: string;
   variant: "good" | "damaged" | "missing" | "unknown";
 }
 
 const CONDITIONS: ConditionOption[] = [
-  { value: "G", label: "Good", variant: "good" },
-  { value: "S", label: "Slightly Damaged", variant: "damaged" },
-  { value: "D", label: "Damaged", variant: "damaged" },
-  { value: "C", label: "Converted", variant: "damaged" },
-  { value: "T", label: "Toppled", variant: "damaged" },
-  { value: "R", label: "Remains", variant: "damaged" },
-  { value: "M", label: "Moved", variant: "missing" },
-  { value: "Q", label: "Possibly Missing", variant: "damaged" },
-  { value: "P", label: "Inaccessible", variant: "unknown" },
-  { value: "X", label: "Destroyed", variant: "missing" },
-  { value: "V", label: "Unreachable but Visible", variant: "unknown" },
-  { value: "N", label: "Couldn't Find", variant: "missing" },
-  { value: "U", label: "Unknown", variant: "unknown" },
+  { value: "G", label: "Good", icon: "c_good.png", variant: "good" },
+  { value: "S", label: "Slightly Damaged", icon: "c_slightlydamaged.png", variant: "damaged" },
+  { value: "D", label: "Damaged", icon: "c_damaged.png", variant: "damaged" },
+  { value: "C", label: "Converted", icon: "c_slightlydamaged.png", variant: "damaged" },
+  { value: "T", label: "Toppled", icon: "c_toppled.png", variant: "damaged" },
+  { value: "R", label: "Remains", icon: "c_toppled.png", variant: "damaged" },
+  { value: "M", label: "Moved", icon: "c_toppled.png", variant: "missing" },
+  { value: "Q", label: "Possibly Missing", icon: "c_possiblymissing.png", variant: "damaged" },
+  { value: "P", label: "Inaccessible", icon: "c_unknown.png", variant: "unknown" },
+  { value: "X", label: "Destroyed", icon: "c_definitelymissing.png", variant: "missing" },
+  { value: "V", label: "Unreachable but Visible", icon: "c_unreachablebutvisible.png", variant: "unknown" },
+  { value: "N", label: "Couldn't Find", icon: "c_possiblymissing.png", variant: "missing" },
+  { value: "U", label: "Unknown", icon: "c_unknown.png", variant: "unknown" },
 ];
 
 interface ConditionSelectorProps {
@@ -56,6 +57,11 @@ export default function ConditionSelector({
         className="w-full px-3 py-2 border border-gray-300 rounded-md bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-trig-green-500 flex items-center justify-between"
       >
         <Badge variant={selectedCondition.variant}>
+          <img
+            src={`/icons/conditions/${selectedCondition.icon}`}
+            alt=""
+            className="w-4 h-4 inline-block mr-1.5"
+          />
           {selectedCondition.label}
         </Badge>
         <svg
@@ -85,7 +91,7 @@ export default function ConditionSelector({
           />
           
           {/* Options */}
-          <div className="absolute z-20 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg">
+          <div className="absolute z-20 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-64 overflow-y-auto">
             {CONDITIONS.map((condition) => (
               <button
                 key={condition.value}
@@ -95,7 +101,14 @@ export default function ConditionSelector({
                   condition.value === value ? "bg-gray-50" : ""
                 }`}
               >
-                <Badge variant={condition.variant}>{condition.label}</Badge>
+                <Badge variant={condition.variant}>
+                  <img
+                    src={`/icons/conditions/${condition.icon}`}
+                    alt=""
+                    className="w-4 h-4 inline-block mr-1.5"
+                  />
+                  {condition.label}
+                </Badge>
                 {condition.value === value && (
                   <svg
                     className="w-4 h-4 text-trig-green-600 ml-auto"

--- a/web/src/components/logs/LogForm.tsx
+++ b/web/src/components/logs/LogForm.tsx
@@ -19,6 +19,7 @@ interface LogFormProps {
   trigLatitude: number;
   trigLongitude: number;
   existingLog?: Log;
+  defaultCondition?: string;
   onSubmit: (data: LogCreateInput | LogUpdateInput) => Promise<void>;
   onCancel: () => void;
   isSubmitting: boolean;
@@ -31,6 +32,7 @@ export default function LogForm({
   trigLatitude,
   trigLongitude,
   existingLog,
+  defaultCondition = "G",
   onSubmit,
   onCancel,
   isSubmitting,
@@ -44,7 +46,7 @@ export default function LogForm({
   const [formData, setFormData] = useState({
     date: existingLog?.date || new Date().toISOString().split("T")[0],
     time: existingLog?.time || getCurrentTime(), // Use current time for new logs
-    condition: existingLog?.condition || "G",
+    condition: existingLog?.condition || defaultCondition,
     score: existingLog?.score || 5,
     comment: existingLog?.comment || "",
     osgb_gridref: existingLog?.osgb_gridref || trigGridRef,

--- a/web/src/components/photos/PhotoManager.tsx
+++ b/web/src/components/photos/PhotoManager.tsx
@@ -1,6 +1,7 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Photo } from "../../lib/api";
 import { useUploadPhoto, useUpdatePhoto, useDeletePhoto, useRotatePhoto } from "../../hooks/useLogPhotos";
+import { useUserProfile } from "../../hooks/useUserProfile";
 import Button from "../ui/Button";
 import Spinner from "../ui/Spinner";
 import { Trash2, RotateCw, Edit2, X, Check, Upload } from "lucide-react";
@@ -12,6 +13,10 @@ interface PhotoManagerProps {
 }
 
 export default function PhotoManager({ logId, photos, isEditing }: PhotoManagerProps) {
+  // Fetch user's default license preference
+  const { data: userProfile } = useUserProfile("me");
+  const defaultLicense = userProfile?.prefs?.public_ind || "N";
+
   const [editingPhotoId, setEditingPhotoId] = useState<number | null>(null);
   const [editForm, setEditForm] = useState({
     caption: "",
@@ -23,11 +28,18 @@ export default function PhotoManager({ logId, photos, isEditing }: PhotoManagerP
     caption: "",
     text_desc: "",
     type: "T",
-    license: "Y",
+    license: "N", // Will be updated when user profile loads
   });
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [showUploadForm, setShowUploadForm] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Update upload form default license when user profile loads
+  useEffect(() => {
+    if (defaultLicense) {
+      setUploadForm((prev) => ({ ...prev, license: defaultLicense }));
+    }
+  }, [defaultLicense]);
 
   const uploadMutation = useUploadPhoto(logId!);
   const updateMutation = useUpdatePhoto();
@@ -60,7 +72,7 @@ export default function PhotoManager({ logId, photos, isEditing }: PhotoManagerP
         caption: "",
         text_desc: "",
         type: "T",
-        license: "Y",
+        license: defaultLicense,
       });
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
@@ -78,7 +90,7 @@ export default function PhotoManager({ logId, photos, isEditing }: PhotoManagerP
       caption: "",
       text_desc: "",
       type: "T",
-      license: "Y",
+      license: defaultLicense,
     });
     if (fileInputRef.current) {
       fileInputRef.current.value = "";

--- a/web/src/routes/Preferences.tsx
+++ b/web/src/routes/Preferences.tsx
@@ -77,11 +77,7 @@ export default function Preferences() {
           </p>
         </div>
 
-        {/* Visibility Preferences */}
         <Card className="mb-6">
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">
-            Visibility Preferences
-          </h2>
           <div className="grid grid-cols-1 gap-6">
             {/* Status Max Preference */}
             <div>
@@ -120,6 +116,24 @@ export default function Preferences() {
               </select>
               <p className="mt-2 text-xs text-gray-500">
                 Choose your preferred unit for displaying distances
+              </p>
+            </div>
+
+            {/* Default Photo Licence Preference */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Default Photo Licence
+              </label>
+              <select
+                value={user.prefs?.public_ind || "N"}
+                onChange={(e) => handleFieldUpdate("public_ind", e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
+              >
+                <option value="N">Copyright me</option>
+                <option value="Y">Public domain</option>
+              </select>
+              <p className="mt-2 text-xs text-gray-500">
+                Choose the default licence for photos you upload
               </p>
             </div>
           </div>

--- a/web/src/routes/TrigDetail.tsx
+++ b/web/src/routes/TrigDetail.tsx
@@ -20,22 +20,22 @@ import { LogCreateInput, LogUpdateInput } from "../lib/api";
 
 const conditionMap: Record<
   string,
-  { label: string; variant: "good" | "damaged" | "missing" | "unknown" }
+  { label: string; icon: string; variant: "good" | "damaged" | "missing" | "unknown" }
 > = {
-  Z: { label: "Not Logged", variant: "unknown" },
-  N: { label: "Couldn't Find", variant: "missing" },
-  G: { label: "Good", variant: "good" },
-  S: { label: "Slightly Damaged", variant: "damaged" },
-  C: { label: "Converted", variant: "damaged" },
-  D: { label: "Damaged", variant: "damaged" },
-  R: { label: "Remains", variant: "damaged" },
-  T: { label: "Toppled", variant: "damaged" },
-  M: { label: "Moved", variant: "missing" },
-  Q: { label: "Possibly Missing", variant: "damaged" },
-  X: { label: "Destroyed", variant: "missing" },
-  V: { label: "Unreachable but Visible", variant: "unknown" },
-  P: { label: "Inaccessible", variant: "unknown" },
-  U: { label: "Unknown", variant: "unknown" },
+  Z: { label: "Not Logged", icon: "c_unknown.png", variant: "unknown" },
+  N: { label: "Couldn't Find", icon: "c_possiblymissing.png", variant: "missing" },
+  G: { label: "Good", icon: "c_good.png", variant: "good" },
+  S: { label: "Slightly Damaged", icon: "c_slightlydamaged.png", variant: "damaged" },
+  C: { label: "Converted", icon: "c_slightlydamaged.png", variant: "damaged" },
+  D: { label: "Damaged", icon: "c_damaged.png", variant: "damaged" },
+  R: { label: "Remains", icon: "c_toppled.png", variant: "damaged" },
+  T: { label: "Toppled", icon: "c_toppled.png", variant: "damaged" },
+  M: { label: "Moved", icon: "c_toppled.png", variant: "missing" },
+  Q: { label: "Possibly Missing", icon: "c_possiblymissing.png", variant: "damaged" },
+  X: { label: "Destroyed", icon: "c_definitelymissing.png", variant: "missing" },
+  V: { label: "Unreachable but Visible", icon: "c_unreachablebutvisible.png", variant: "unknown" },
+  P: { label: "Inaccessible", icon: "c_unknown.png", variant: "unknown" },
+  U: { label: "Unknown", icon: "c_unknown.png", variant: "unknown" },
 };
 
 export default function TrigDetail() {
@@ -259,7 +259,14 @@ export default function TrigDetail() {
                   <span className="font-semibold text-gray-700">
                     Condition:
                   </span>
-                  <Badge variant={condition.variant}>{condition.label}</Badge>
+                  <Badge variant={condition.variant}>
+                    <img
+                      src={`/icons/conditions/${condition.icon}`}
+                      alt=""
+                      className="w-4 h-4 inline-block mr-1.5"
+                    />
+                    {condition.label}
+                  </Badge>
                 </div>
 
                 {trig.details && (
@@ -541,6 +548,7 @@ export default function TrigDetail() {
               trigNorthings={parseInt(trig.osgb_gridref.substring(7, 12))} // Simplified - would need proper conversion
               trigLatitude={parseFloat(trig.wgs_lat)}
               trigLongitude={parseFloat(trig.wgs_long)}
+              defaultCondition={trig.condition}
               onSubmit={handleLogSubmit}
               onCancel={handleLogCancel}
               isSubmitting={createLogMutation.isPending}


### PR DESCRIPTION
- Add default photo licence preference to Preferences page
- Default photo upload licence to user's preference in PhotoManager
- Default log condition to trigpoint's current condition in LogForm
- Add condition icons to ConditionSelector dropdown
- Add condition icon to trigpoint detail page badge