### PR TITLE
fix(tiles): add Vary: Origin header to enable proper CORS caching

### DIFF
--- a/api/api/v1/endpoints/tiles.py
+++ b/api/api/v1/endpoints/tiles.py
@@ -139,6 +139,7 @@ async def proxy_os_tile(
             media_type="image/png",
             headers={
                 "Cache-Control": "public, max-age=31536000",  # 1 year for Cloudflare
+                "Vary": "Origin",  # Required for Cloudflare to cache CORS correctly
                 "X-Tile-Source": "cache",
                 "X-Tile-Type": "free",  # Cached tiles are always free
             },
@@ -202,6 +203,7 @@ async def proxy_os_tile(
             media_type="image/png",
             headers={
                 "Cache-Control": "public, max-age=31536000",  # 1 year for Cloudflare
+                "Vary": "Origin",  # Required for Cloudflare to cache CORS correctly
                 "X-Tile-Source": "os-api",
                 "X-Tile-Type": "premium" if premium else "free",
             },

--- a/api/tests/test_tile_proxy.py
+++ b/api/tests/test_tile_proxy.py
@@ -176,6 +176,7 @@ class TestTileProxyEndpoint:
             assert response.headers["x-tile-source"] == "cache"
             assert response.headers["x-tile-type"] == "free"
             assert "max-age=31536000" in response.headers["cache-control"]
+            assert response.headers["vary"] == "Origin"  # Required for CORS caching
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Without the Vary header, Cloudflare cached tile responses without knowing they should vary by Origin. This caused CORS errors when serving cached tiles to browser requests with different Origin headers.