### PR TITLE
Add dynamic page titles using useDocumentTitle hook

### DIFF
--- a/web/src/hooks/useDocumentTitle.ts
+++ b/web/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+/**
+ * Hook to update the document title.
+ * Uses useEffect to ensure the title updates when data loads.
+ * 
+ * @param title - The title to set (without suffix). Pass null/undefined to skip.
+ * @param suffix - The suffix to append (default: "TrigpointingUK")
+ */
+export function useDocumentTitle(title: string | null | undefined, suffix = "TrigpointingUK") {
+  useEffect(() => {
+    if (title) {
+      document.title = `${title} | ${suffix}`;
+    }
+  }, [title, suffix]);
+}
+

--- a/web/src/routes/About.tsx
+++ b/web/src/routes/About.tsx
@@ -59,6 +59,7 @@ export default function About() {
   if (error) {
     return (
       <Layout>
+        <title>About | TrigpointingUK</title>
         <div className="max-w-4xl mx-auto">
           <h1 className="text-3xl font-bold text-gray-800 mb-6">About</h1>
           <Card>
@@ -74,6 +75,7 @@ export default function About() {
   if (!buildInfo) {
     return (
       <Layout>
+        <title>About | TrigpointingUK</title>
         <div className="max-w-4xl mx-auto">
           <h1 className="text-3xl font-bold text-gray-800 mb-6">About</h1>
           <Card>
@@ -86,6 +88,7 @@ export default function About() {
 
   return (
     <Layout>
+      <title>About | TrigpointingUK</title>
       <div className="max-w-4xl mx-auto">
         <h1 className="text-3xl font-bold text-gray-800 mb-6">About Trigpointing UK</h1>
 

--- a/web/src/routes/Admin.tsx
+++ b/web/src/routes/Admin.tsx
@@ -1396,6 +1396,7 @@ export default function Admin() {
   if (!hasAdminRole) {
     return (
       <Layout>
+        <title>Admin | TrigpointingUK</title>
         <div className="max-w-4xl mx-auto">
           <Card>
             <div className="text-center py-12">
@@ -1416,6 +1417,7 @@ export default function Admin() {
   if (isAuth0Loading || isCheckingScope || hasAdminScope === null) {
     return (
       <Layout>
+        <title>Admin | TrigpointingUK</title>
         <div className="max-w-4xl mx-auto">
           <Card>
             <div className="text-center py-12">
@@ -1434,6 +1436,7 @@ export default function Admin() {
   if (!hasAdminScope) {
     return (
       <Layout>
+        <title>Admin | TrigpointingUK</title>
         <div className="max-w-4xl mx-auto">
           <Card>
             <div className="text-center py-12">
@@ -1454,6 +1457,7 @@ export default function Admin() {
   // Has both role and scope - show admin page
   return (
     <Layout>
+      <title>Admin | TrigpointingUK</title>
       <div className="max-w-6xl mx-auto">
         <Card className="mb-6">
           <h1 className="text-3xl font-bold text-gray-800 mb-4">

--- a/web/src/routes/AppDetail.tsx
+++ b/web/src/routes/AppDetail.tsx
@@ -7,6 +7,7 @@ export default function AppDetail() {
 
   return (
     <Layout>
+      <title>Trig #{id} | TrigpointingUK</title>
       <div className="max-w-4xl mx-auto">
         <Card>
           <h1 className="text-3xl font-bold text-trig-green-600 mb-4">

--- a/web/src/routes/Attributions.tsx
+++ b/web/src/routes/Attributions.tsx
@@ -150,6 +150,7 @@ export default function Attributions() {
   if (error) {
     return (
       <Layout>
+        <title>Attributions | TrigpointingUK</title>
         <div className="max-w-6xl mx-auto">
           <h1 className="text-3xl font-bold text-gray-800 mb-6">
             Open Source Attributions
@@ -174,6 +175,7 @@ export default function Attributions() {
   if (!data) {
     return (
       <Layout>
+        <title>Attributions | TrigpointingUK</title>
         <div className="max-w-6xl mx-auto">
           <h1 className="text-3xl font-bold text-gray-800 mb-6">
             Open Source Attributions
@@ -188,6 +190,7 @@ export default function Attributions() {
 
   return (
     <Layout>
+      <title>Attributions | TrigpointingUK</title>
       <div className="max-w-6xl mx-auto">
         <h1 className="text-3xl font-bold text-gray-800 mb-2">
           Open Source Attributions

--- a/web/src/routes/Contact.tsx
+++ b/web/src/routes/Contact.tsx
@@ -153,6 +153,7 @@ export default function Contact() {
 
   return (
     <Layout>
+      <title>Contact | TrigpointingUK</title>
       <div className="max-w-2xl mx-auto">
         <h1 className="text-3xl font-bold text-gray-800 mb-6">Contact Us</h1>
 

--- a/web/src/routes/FindTrigs.tsx
+++ b/web/src/routes/FindTrigs.tsx
@@ -283,6 +283,7 @@ export default function FindTrigs() {
 
   return (
     <Layout>
+      <title>Find Trigpoints | TrigpointingUK</title>
       <div className="max-w-7xl mx-auto">
         {/* Page Header */}
         <div className="mb-6">

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -227,6 +227,7 @@ function RecentLogsSection() {
 export default function Home() {
   return (
     <Layout>
+      <title>TrigpointingUK</title>
       <div className="flex flex-col-reverse lg:flex-row gap-6">
         {/* Sidebar - bottom on mobile, left on desktop */}
         <Sidebar />

--- a/web/src/routes/LegacyMigration.tsx
+++ b/web/src/routes/LegacyMigration.tsx
@@ -37,6 +37,7 @@ export default function LegacyMigration() {
     const username = user?.name || user?.nickname || user?.email || "there";
     return (
       <Layout>
+        <title>Account Migration | TrigpointingUK</title>
         <div className="max-w-2xl mx-auto">
           <h1 className="text-3xl font-bold text-gray-800 mb-6">
             Legacy Account Migration
@@ -161,6 +162,7 @@ export default function LegacyMigration() {
 
   return (
     <Layout>
+      <title>Account Migration | TrigpointingUK</title>
       <div className="max-w-2xl mx-auto">
         <h1 className="text-3xl font-bold text-gray-800 mb-6">
           Legacy Account Migration

--- a/web/src/routes/LogDetail.tsx
+++ b/web/src/routes/LogDetail.tsx
@@ -12,6 +12,7 @@ import { useTrigDetail } from "../hooks/useTrigDetail";
 import { useUpdateLog } from "../hooks/useUpdateLog";
 import { useDeleteLog } from "../hooks/useDeleteLog";
 import { useCurrentUser } from "../hooks/useCurrentUser";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { LogUpdateInput, DuplicateLogError } from "../lib/api";
 
 export default function LogDetail() {
@@ -29,6 +30,9 @@ export default function LogDetail() {
     isLoading,
     error,
   } = useLogDetail(logIdNum!);
+
+  // Update document title when log data loads
+  useDocumentTitle(log ? `Log #${log.id} - ${log.trig_name}` : null);
 
   // Get current user's database profile
   const { data: currentUser } = useCurrentUser();

--- a/web/src/routes/Logs.tsx
+++ b/web/src/routes/Logs.tsx
@@ -151,6 +151,7 @@ export default function Logs() {
   if (error) {
     return (
       <Layout>
+        <title>Recent Logs | TrigpointingUK</title>
         <div className="max-w-7xl mx-auto">
           <h1 className="text-3xl font-bold text-gray-800 mb-6">Visit Logs</h1>
           <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
@@ -166,6 +167,7 @@ export default function Logs() {
 
   return (
     <Layout>
+      <title>Recent Logs | TrigpointingUK</title>
       <div className="max-w-4xl mx-auto relative" ref={containerRef}>
         {/* Header */}
         <div className="mb-6">

--- a/web/src/routes/Map.tsx
+++ b/web/src/routes/Map.tsx
@@ -461,6 +461,7 @@ export default function Map() {
   
   return (
     <Layout>
+      <title>Map | TrigpointingUK</title>
       <div className="flex h-[calc(100vh-4rem-7rem)] relative -mx-4 -mb-6">
         {/* Sidebar */}
         <div

--- a/web/src/routes/NotFound.tsx
+++ b/web/src/routes/NotFound.tsx
@@ -5,6 +5,7 @@ import Button from "../components/ui/Button";
 export default function NotFound() {
   return (
     <Layout>
+      <title>Page Not Found | TrigpointingUK</title>
       <div className="text-center py-12">
         <div className="text-6xl mb-4">🧭</div>
         <h1 className="text-4xl font-bold text-gray-800 mb-4">404 - Not Found</h1>

--- a/web/src/routes/PhotoAlbum.tsx
+++ b/web/src/routes/PhotoAlbum.tsx
@@ -107,6 +107,7 @@ export default function PhotoAlbum() {
   if (error) {
     return (
       <Layout>
+        <title>Photo Album | TrigpointingUK</title>
         <div className="max-w-7xl mx-auto">
           <h1 className="text-3xl font-bold text-gray-800 mb-6">Photo Gallery</h1>
           <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
@@ -122,6 +123,7 @@ export default function PhotoAlbum() {
 
   return (
     <Layout>
+      <title>Photo Album | TrigpointingUK</title>
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <div className="mb-6">

--- a/web/src/routes/PhotoDetail.tsx
+++ b/web/src/routes/PhotoDetail.tsx
@@ -4,6 +4,7 @@ import { useQueryClient, useQuery } from '@tanstack/react-query';
 import Layout from '../components/layout/Layout';
 import Spinner from '../components/ui/Spinner';
 import { usePhotoSwipe } from '../hooks/usePhotoSwipe';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { Photo } from '../lib/api';
 import 'photoswipe/style.css';
 import '../components/photos/photoswipe-custom.css';
@@ -135,6 +136,13 @@ export default function PhotoDetail() {
       };
     });
   };
+
+  // Update document title when photo data is available
+  useDocumentTitle(
+    photoForViewer && photoForViewer.trig_name && photoForViewer.user_name
+      ? `${photoForViewer.trig_name} by ${photoForViewer.user_name}`
+      : null
+  );
 
   // Open PhotoSwipe when we have a photo
   usePhotoSwipe({

--- a/web/src/routes/Preferences.tsx
+++ b/web/src/routes/Preferences.tsx
@@ -38,6 +38,7 @@ export default function Preferences() {
   if (isLoading) {
     return (
       <Layout>
+        <title>Preferences | TrigpointingUK</title>
         <div className="max-w-4xl mx-auto">
           <div className="py-12 text-center">
             <Spinner size="lg" />
@@ -51,6 +52,7 @@ export default function Preferences() {
   if (error || !user || !user.prefs) {
     return (
       <Layout>
+        <title>Preferences | TrigpointingUK</title>
         <div className="max-w-4xl mx-auto">
           <Card>
             <div className="text-center py-12">
@@ -66,6 +68,7 @@ export default function Preferences() {
 
   return (
     <Layout>
+      <title>Preferences | TrigpointingUK</title>
       <div className="max-w-4xl mx-auto">
         {/* Header */}
         <div className="mb-6">

--- a/web/src/routes/Search.tsx
+++ b/web/src/routes/Search.tsx
@@ -232,6 +232,7 @@ export default function Search() {
   if (!query || query.length < 2) {
     return (
       <>
+        <title>Search | TrigpointingUK</title>
         <Header />
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-2xl mx-auto text-center">
@@ -264,6 +265,7 @@ export default function Search() {
 
   return (
     <>
+      <title>Search | TrigpointingUK</title>
       <Header />
       <div className="container mx-auto px-4 py-6">
         {/* Search Header */}

--- a/web/src/routes/TrigDetail.tsx
+++ b/web/src/routes/TrigDetail.tsx
@@ -17,6 +17,7 @@ import { useUserTrigLogs } from "../hooks/useUserTrigLogs";
 import { useCurrentUser } from "../hooks/useCurrentUser";
 import { useCreateLog } from "../hooks/useCreateLog";
 import { useAreasContaining, type Area } from "../hooks/useAreasContaining";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { LogCreateInput, LogUpdateInput, DuplicateLogError } from "../lib/api";
 
 const conditionMap: Record<
@@ -56,6 +57,9 @@ export default function TrigDetail() {
     isLoading: isTrigLoading,
     error: trigError,
   } = useTrigDetail(trigIdNum!);
+
+  // Update document title when trig data loads
+  useDocumentTitle(trig ? `${trig.waypoint} - ${trig.name}` : null);
 
   const {
     data: logsData,

--- a/web/src/routes/TrigPhotos.tsx
+++ b/web/src/routes/TrigPhotos.tsx
@@ -8,6 +8,7 @@ import Spinner from "../components/ui/Spinner";
 import PhotoGrid from "../components/photos/PhotoGrid";
 import { useTrigPhotos } from "../hooks/useTrigPhotos";
 import { useTrigDetail } from "../hooks/useTrigDetail";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { Photo } from "../lib/api";
 
 interface PhotosResponse {
@@ -36,6 +37,9 @@ export default function TrigPhotos() {
   } = useTrigPhotos(trigIdNum!);
 
   const { data: trig } = useTrigDetail(trigIdNum!);
+
+  // Update document title when trig data loads
+  useDocumentTitle(trig ? `Photos: ${trig.name}` : null);
 
   // Intersection observer for infinite scroll
   const { ref: loadMoreRef, inView } = useInView({

--- a/web/src/routes/UserLogs.tsx
+++ b/web/src/routes/UserLogs.tsx
@@ -7,6 +7,7 @@ import Spinner from "../components/ui/Spinner";
 import LogList from "../components/logs/LogList";
 import { useUserLogs } from "../hooks/useUserLogs";
 import { useUserProfile } from "../hooks/useUserProfile";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 
 export default function UserLogs() {
   const { userId } = useParams<{ userId: string }>();
@@ -22,6 +23,9 @@ export default function UserLogs() {
   } = useUserLogs(userId!);
 
   const { data: user } = useUserProfile(userId!);
+
+  // Update document title when user data loads
+  useDocumentTitle(user?.name ? `${user.name}'s Logs` : null);
 
   // Intersection observer for infinite scroll
   const { ref: loadMoreRef, inView } = useInView({

--- a/web/src/routes/UserPhotos.tsx
+++ b/web/src/routes/UserPhotos.tsx
@@ -8,6 +8,7 @@ import Spinner from "../components/ui/Spinner";
 import PhotoGrid from "../components/photos/PhotoGrid";
 import { useUserPhotos } from "../hooks/useUserPhotos";
 import { useUserProfile } from "../hooks/useUserProfile";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { Photo } from "../lib/api";
 
 interface PhotosResponse {
@@ -34,6 +35,9 @@ export default function UserPhotos() {
   } = useUserPhotos(userId!);
 
   const { data: user } = useUserProfile(userId!);
+
+  // Update document title when user data loads
+  useDocumentTitle(user?.name ? `${user.name}'s Photos` : null);
 
   // Intersection observer for infinite scroll
   const { ref: loadMoreRef, inView } = useInView({

--- a/web/src/routes/UserProfile.tsx
+++ b/web/src/routes/UserProfile.tsx
@@ -10,6 +10,7 @@ import EditableField from "../components/ui/EditableField";
 import LogList from "../components/logs/LogList";
 import { useUserProfile, updateUserProfile } from "../hooks/useUserProfile";
 import { useUserLogs } from "../hooks/useUserLogs";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 
 // Helper function to decode JWT payload
 interface JWTPayload {
@@ -44,6 +45,9 @@ export default function UserProfile() {
   // If no userId in URL, fetch "me", otherwise fetch the specified user
   const targetUserId = userId || "me";
   const { data: user, isLoading, error } = useUserProfile(targetUserId);
+
+  // Update document title when user data loads
+  useDocumentTitle(user ? `${user.name}'s Profile` : null);
 
   // Own profile if: no userId param, or userId matches the logged-in user's ID
   const isOwnProfile = !userId || (authUser && userId === authUser.sub);

--- a/web/src/routes/UsersPage.tsx
+++ b/web/src/routes/UsersPage.tsx
@@ -148,6 +148,7 @@ export default function UsersPage() {
 
   return (
     <Layout>
+      <title>Users | TrigpointingUK</title>
       <div className="max-w-6xl mx-auto flex flex-col gap-6">
         <div className="space-y-2">
           <p className="text-sm uppercase tracking-wide text-trig-green-600 font-semibold">

--- a/web/src/routes/admin/LogsNeedsAttention.tsx
+++ b/web/src/routes/admin/LogsNeedsAttention.tsx
@@ -289,6 +289,7 @@ export default function LogsNeedsAttention() {
   if (!hasAdminRole) {
     return (
       <Layout>
+        <title>Logs Needs Attention | TrigpointingUK</title>
         <div className="max-w-6xl mx-auto">
           <Card>
             <div className="text-center py-12">
@@ -315,6 +316,7 @@ export default function LogsNeedsAttention() {
 
   return (
     <Layout>
+      <title>Logs Needs Attention | TrigpointingUK</title>
       <div className="max-w-6xl mx-auto">
         <Card className="mb-6">
           <div className="flex items-center justify-between">

--- a/web/src/routes/admin/NeedsAttention.tsx
+++ b/web/src/routes/admin/NeedsAttention.tsx
@@ -72,6 +72,7 @@ export default function NeedsAttention() {
   if (!hasAdminRole) {
     return (
       <Layout>
+        <title>Needs Attention | TrigpointingUK</title>
         <div className="max-w-6xl mx-auto">
           <Card>
             <div className="text-center py-12">
@@ -98,6 +99,7 @@ export default function NeedsAttention() {
 
   return (
     <Layout>
+      <title>Needs Attention | TrigpointingUK</title>
       <div className="max-w-6xl mx-auto">
         <Card className="mb-6">
           <div className="flex items-center justify-between">

--- a/web/src/routes/admin/TrigEdit.tsx
+++ b/web/src/routes/admin/TrigEdit.tsx
@@ -6,6 +6,7 @@ import Card from "../../components/ui/Card";
 import Spinner from "../../components/ui/Spinner";
 import Button from "../../components/ui/Button";
 import LinkedCoordinates from "../../components/admin/LinkedCoordinates";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import {
   fetchTrigForEdit,
   fetchStatuses,
@@ -76,6 +77,9 @@ export default function TrigEdit() {
   const [error, setError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
+
+  // Update document title when trig data loads
+  useDocumentTitle(trig ? `Edit: ${trig.name}` : null);
 
   // Form fields
   const [name, setName] = useState("");


### PR DESCRIPTION
- Create useDocumentTitle hook for reliable title updates
- Add static titles to pages using React 19 native <title> tag
- Add dynamic titles to data-driven pages (trigs, logs, photos, profiles)
- Titles update when async data loads via useEffect