### PR TITLE
Show archive preferences to all users; add admin daily frequencies

### DIFF
--- a/api/commands/send_archives.py
+++ b/api/commands/send_archives.py
@@ -31,16 +31,21 @@ FREQUENCY_INTERVALS = {
     "W": timedelta(weeks=1),
     "M": timedelta(days=30),
     "Y": timedelta(days=365),
+    "D": timedelta(days=1),
+    "B": timedelta(days=1),
 }
 
 FALLBACK_INTERVALS = {
     "W": timedelta(days=30),
     "M": timedelta(days=365),
+    "B": timedelta(weeks=1),
 }
 
 ACTIVE_WINDOWS = {
     "W": timedelta(weeks=1),
     "M": timedelta(days=30),
+    # B: daily if active in the last day, else weekly cadence
+    "B": timedelta(days=1),
 }
 
 
@@ -73,6 +78,8 @@ def _is_user_due(db: Session, user: User, now: datetime) -> tuple[bool, str]:
     For W: send weekly if active in last week, else monthly.
     For M: send monthly if active in last month, else yearly.
     For Y: send yearly always.
+    For D: send at most daily when there is new activity since the last archive.
+    For B: send daily if active in the last day, else weekly (same activity rule as W/M).
     """
     freq = str(user.archive_frequency or "N")
     if freq == "N":
@@ -86,8 +93,22 @@ def _is_user_due(db: Session, user: User, now: datetime) -> tuple[bool, str]:
             return False, "yearly: not yet due"
         return True, "yearly: due"
 
-    active_window = ACTIVE_WINDOWS.get(freq)
     last_act = _last_activity(db, user_id)
+
+    if freq == "D":
+        interval = FREQUENCY_INTERVALS["D"]
+        if last_sent and (now - last_sent) < interval:
+            return False, "daily: not yet due"
+        if last_sent and last_act:
+            last_act_aware = last_act.replace(tzinfo=timezone.utc)
+            if last_act_aware <= last_sent:
+                return False, "daily: no new activity since last archive"
+        return True, "daily: due"
+
+    if freq not in ("W", "M", "B"):
+        return False, f"unsupported-frequency={freq}"
+
+    active_window = ACTIVE_WINDOWS.get(freq)
     is_active = (
         last_act is not None
         and active_window is not None
@@ -96,10 +117,14 @@ def _is_user_due(db: Session, user: User, now: datetime) -> tuple[bool, str]:
 
     if is_active:
         interval = FREQUENCY_INTERVALS[freq]
-        label = "weekly" if freq == "W" else "monthly"
+        label = {"W": "weekly", "M": "monthly", "B": "daily"}[freq]
     else:
         interval = FALLBACK_INTERVALS[freq]
-        label = "monthly-fallback" if freq == "W" else "yearly-fallback"
+        label = {
+            "W": "monthly-fallback",
+            "M": "yearly-fallback",
+            "B": "weekly-fallback",
+        }[freq]
 
     if last_sent and (now - last_sent) < interval:
         return False, f"{label}: not yet due"

--- a/api/schemas/user.py
+++ b/api/schemas/user.py
@@ -128,7 +128,11 @@ class UserPrefs(BaseModel):
     )
     archive_frequency: str = Field(
         "N",
-        description="Archive email frequency: N=never, Y=yearly, M=monthly-if-active-else-yearly, W=weekly-if-active-else-monthly",
+        description=(
+            "Archive email frequency: N=never, Y=yearly, "
+            "M=monthly-if-active-else-yearly, W=weekly-if-active-else-monthly, "
+            "D=daily-if-new-activity, B=daily-if-active-else-weekly"
+        ),
     )
     archive_format: str = Field(
         "R",
@@ -175,8 +179,11 @@ class UserUpdate(BaseModel):
     )
     archive_frequency: Optional[str] = Field(
         None,
-        pattern="^[NYMW]$",
-        description="Archive email frequency: N=never, Y=yearly, M=monthly-if-active, W=weekly-if-active",
+        pattern="^[NYMWDB]$",
+        description=(
+            "Archive email frequency: N=never, Y=yearly, M=monthly-if-active, "
+            "W=weekly-if-active, D=daily-if-new-activity, B=daily-if-active-else-weekly"
+        ),
     )
     archive_format: Optional[str] = Field(
         None,

--- a/api/tests/test_archive_command.py
+++ b/api/tests/test_archive_command.py
@@ -2,10 +2,12 @@
 Tests for the send_archives command scheduling logic.
 """
 
-from datetime import datetime, timedelta, timezone
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
 
 from api.commands.send_archives import _is_user_due
-from api.models.user import User, UserArchive
+from api.models.trig import Trig
+from api.models.user import TLog, User, UserArchive
 
 
 def _make_user(db, **overrides):
@@ -28,6 +30,55 @@ def _make_user(db, **overrides):
     db.commit()
     db.refresh(user)
     return user
+
+
+def _add_published_log(db, user: User, *, upd_timestamp: datetime) -> None:
+    suffix = uuid.uuid4().hex[:6]
+    trig = Trig(
+        waypoint=f"Z{suffix}"[:8],
+        name="Schedule test trig",
+        status_id=10,
+        user_added=0,
+        current_use="Passive station",
+        historic_use="Primary",
+        condition="G",
+        wgs_lat=51.5,
+        wgs_long=-0.1,
+        wgs_height=0,
+        osgb_eastings=530000,
+        osgb_northings=180000,
+        osgb_gridref="TQ 30000 80000",
+        osgb_height=95,
+        fb_number="",
+        stn_number="",
+        permission_ind="Y",
+        postcode=None,
+        town="Test",
+        needs_attention=0,
+        attention_comment="",
+        crt_date=date(2023, 1, 1),
+        crt_time=time(12, 0, 0),
+        crt_user_id=user.id,
+        crt_ip_addr="127.0.0.1",
+    )
+    db.add(trig)
+    db.commit()
+    db.refresh(trig)
+    log = TLog(
+        trig_id=trig.id,
+        user_id=user.id,
+        date=date(2024, 6, 15),
+        time=time(14, 30),
+        condition="G",
+        comment="schedule test",
+        score=1,
+        ip_addr="127.0.0.1",
+        source="W",
+        status="P",
+        upd_timestamp=upd_timestamp,
+    )
+    db.add(log)
+    db.commit()
 
 
 class TestIsUserDue:
@@ -111,3 +162,97 @@ class TestIsUserDue:
         is_due, reason = _is_user_due(db, user, now)
         assert is_due is False
         assert "not yet due" in reason
+
+    def test_daily_no_previous(self, db):
+        user = _make_user(db, name="daily1", archive_frequency="D")
+        now = datetime.now(timezone.utc)
+        is_due, reason = _is_user_due(db, user, now)
+        assert is_due is True
+        assert "daily" in reason
+
+    def test_daily_recently_sent(self, db):
+        user = _make_user(db, name="daily2", archive_frequency="D")
+        now = datetime.now(timezone.utc)
+        record = UserArchive(
+            user_id=user.id,
+            status="S",
+            frequency_at_send="D",
+            format_at_send="C",
+            created_at=now - timedelta(hours=2),
+        )
+        db.add(record)
+        db.commit()
+        is_due, reason = _is_user_due(db, user, now)
+        assert is_due is False
+        assert "not yet due" in reason
+
+    def test_daily_no_new_activity_since_send(self, db):
+        user = _make_user(db, name="daily3", archive_frequency="D")
+        now = datetime.now(timezone.utc)
+        sent_at = now - timedelta(days=2)
+        record = UserArchive(
+            user_id=user.id,
+            status="S",
+            frequency_at_send="D",
+            format_at_send="C",
+            created_at=sent_at,
+        )
+        db.add(record)
+        db.commit()
+        _add_published_log(db, user, upd_timestamp=sent_at - timedelta(days=1))
+        is_due, reason = _is_user_due(db, user, now)
+        assert is_due is False
+        assert "no new activity" in reason
+
+    def test_daily_new_activity_since_send(self, db):
+        user = _make_user(db, name="daily4", archive_frequency="D")
+        now = datetime.now(timezone.utc)
+        sent_at = now - timedelta(days=2)
+        record = UserArchive(
+            user_id=user.id,
+            status="S",
+            frequency_at_send="D",
+            format_at_send="C",
+            created_at=sent_at,
+        )
+        db.add(record)
+        db.commit()
+        _add_published_log(db, user, upd_timestamp=now - timedelta(hours=1))
+        is_due, reason = _is_user_due(db, user, now)
+        assert is_due is True
+
+    def test_bursty_active_daily_cadence(self, db):
+        user = _make_user(db, name="burst1", archive_frequency="B")
+        now = datetime.now(timezone.utc)
+        sent_at = now - timedelta(days=2)
+        record = UserArchive(
+            user_id=user.id,
+            status="S",
+            frequency_at_send="B",
+            format_at_send="C",
+            created_at=sent_at,
+        )
+        db.add(record)
+        db.commit()
+        _add_published_log(db, user, upd_timestamp=now - timedelta(hours=1))
+        is_due, reason = _is_user_due(db, user, now)
+        assert is_due is True
+        assert "daily" in reason
+
+    def test_bursty_inactive_weekly_cadence(self, db):
+        user = _make_user(db, name="burst2", archive_frequency="B")
+        now = datetime.now(timezone.utc)
+        sent_at = now - timedelta(days=10)
+        record = UserArchive(
+            user_id=user.id,
+            status="S",
+            frequency_at_send="B",
+            format_at_send="C",
+            created_at=sent_at,
+        )
+        db.add(record)
+        db.commit()
+        _add_published_log(db, user, upd_timestamp=now - timedelta(days=5))
+        is_due, reason = _is_user_due(db, user, now)
+        assert is_due is True
+        assert "weekly-fallback" in reason

--- a/web/src/components/archive/ArchivePreferencesPanel.tsx
+++ b/web/src/components/archive/ArchivePreferencesPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
@@ -16,6 +16,15 @@ const FREQUENCY_OPTIONS = [
   { value: "Y", label: "Yearly" },
   { value: "M", label: "Monthly (or yearly if no recent activity)" },
   { value: "W", label: "Weekly (or monthly if no recent activity)" },
+];
+
+/** Shown in the UI only for api-admin (values still accepted by the API for any user). */
+const ADMIN_EXTRA_FREQUENCY_OPTIONS = [
+  { value: "D", label: "Daily" },
+  {
+    value: "B",
+    label: "Daily (or weekly if no recent activity)",
+  },
 ];
 
 const FORMAT_OPTIONS = [
@@ -59,6 +68,7 @@ interface ArchiveHistoryResponse {
 
 interface ArchivePreferencesPanelProps {
   user: UserProfile;
+  hasAdminRole: boolean;
 }
 
 function formatBytes(bytes: number): string {
@@ -80,6 +90,7 @@ function formatDate(iso: string): string {
 
 export default function ArchivePreferencesPanel({
   user,
+  hasAdminRole,
 }: ArchivePreferencesPanelProps) {
   const { getAccessTokenSilently } = useAuth0();
   const queryClient = useQueryClient();
@@ -87,6 +98,19 @@ export default function ArchivePreferencesPanel({
 
   const currentFrequency = user.prefs?.archive_frequency ?? "N";
   const currentFormat = user.prefs?.archive_format ?? "R";
+
+  const frequencySelectOptions = useMemo(() => {
+    if (hasAdminRole) {
+      return [...FREQUENCY_OPTIONS, ...ADMIN_EXTRA_FREQUENCY_OPTIONS];
+    }
+    if (currentFrequency === "D" || currentFrequency === "B") {
+      const keep = ADMIN_EXTRA_FREQUENCY_OPTIONS.filter(
+        (o) => o.value === currentFrequency,
+      );
+      return [...FREQUENCY_OPTIONS, ...keep];
+    }
+    return FREQUENCY_OPTIONS;
+  }, [hasAdminRole, currentFrequency]);
 
   const {
     data: history,
@@ -169,7 +193,7 @@ export default function ArchivePreferencesPanel({
             }
             className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-blue-500 focus:border-blue-500"
           >
-            {FREQUENCY_OPTIONS.map((opt) => (
+            {frequencySelectOptions.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
               </option>

--- a/web/src/routes/Preferences.tsx
+++ b/web/src/routes/Preferences.tsx
@@ -469,9 +469,8 @@ export default function Preferences() {
           <ListsPreferencesPanel hasAdminRole={hasAdminRole} />
         )}
 
-        {/* Data Archive — admin-only until feature is ready for release */}
-        {isAuthenticated && hasAdminRole && user && (
-          <ArchivePreferencesPanel user={user} />
+        {isAuthenticated && user && (
+          <ArchivePreferencesPanel user={user} hasAdminRole={hasAdminRole} />
         )}
       </div>
     </>


### PR DESCRIPTION
Expose Data Archive Emails on preferences for every signed-in user. Admins see extra frequency options Daily (D) and daily-or-weekly (B). Accept D and B in UserUpdate; extend send_archives scheduling for both. Add command tests for the new modes.

Made-with: Cursor