### PR TITLE
Fix archive HTML viewer profile link path

### DIFF
--- a/api/templates/archive_viewer.html
+++ b/api/templates/archive_viewer.html
@@ -178,7 +178,7 @@ function init() {
   const user = DATA.user || {};
 
   document.getElementById("headerMeta").innerHTML =
-    '<a href="https://trigpointing.uk/users/' + user.id + '" class="trig-link">' +
+    '<a href="https://trigpointing.uk/profile/' + user.id + '" class="trig-link">' +
     esc(user.username) + '</a> \u2014 ' + (DATA.export_date || "").split("T")[0];
   document.getElementById("footerDate").textContent =
     " on " + (DATA.export_date || "").split("T")[0];

--- a/api/tests/test_archive_service.py
+++ b/api/tests/test_archive_service.py
@@ -235,7 +235,7 @@ class TestGenerateArchiveZip:
             assert "<table" in html
             assert "trigpointing.uk/trigs/" in html
             assert "trigpointing.uk/logs/" in html
-            assert "trigpointing.uk/users/" in html
+            assert "trigpointing.uk/profile/" in html
             assert "trigpointing.uk/map?" in html
             assert "stretched53_default.png" in html
 


### PR DESCRIPTION
Use /profile/{id} instead of /users/{id} for the public site SPA route. Update archive service test assertion accordingly.

Made-with: Cursor