### PR TITLE
Treat archive frequency D as unconditional daily

### DIFF
--- a/api/commands/send_archives.py
+++ b/api/commands/send_archives.py
@@ -78,8 +78,8 @@ def _is_user_due(db: Session, user: User, now: datetime) -> tuple[bool, str]:
     For W: send weekly if active in last week, else monthly.
     For M: send monthly if active in last month, else yearly.
     For Y: send yearly always.
-    For D: send at most daily when there is new activity since the last archive.
-    For B: send daily if active in the last day, else weekly (same activity rule as W/M).
+    For D: send at most once per rolling day (no activity gate; true daily digest).
+    For B: send daily if active in the last day, else weekly (activity gate like W/M).
     """
     freq = str(user.archive_frequency or "N")
     if freq == "N":
@@ -93,17 +93,13 @@ def _is_user_due(db: Session, user: User, now: datetime) -> tuple[bool, str]:
             return False, "yearly: not yet due"
         return True, "yearly: due"
 
-    last_act = _last_activity(db, user_id)
-
     if freq == "D":
         interval = FREQUENCY_INTERVALS["D"]
         if last_sent and (now - last_sent) < interval:
             return False, "daily: not yet due"
-        if last_sent and last_act:
-            last_act_aware = last_act.replace(tzinfo=timezone.utc)
-            if last_act_aware <= last_sent:
-                return False, "daily: no new activity since last archive"
         return True, "daily: due"
+
+    last_act = _last_activity(db, user_id)
 
     if freq not in ("W", "M", "B"):
         return False, f"unsupported-frequency={freq}"

--- a/api/schemas/user.py
+++ b/api/schemas/user.py
@@ -131,7 +131,7 @@ class UserPrefs(BaseModel):
         description=(
             "Archive email frequency: N=never, Y=yearly, "
             "M=monthly-if-active-else-yearly, W=weekly-if-active-else-monthly, "
-            "D=daily-if-new-activity, B=daily-if-active-else-weekly"
+            "D=daily, B=daily-if-active-else-weekly"
         ),
     )
     archive_format: str = Field(
@@ -182,7 +182,7 @@ class UserUpdate(BaseModel):
         pattern="^[NYMWDB]$",
         description=(
             "Archive email frequency: N=never, Y=yearly, M=monthly-if-active, "
-            "W=weekly-if-active, D=daily-if-new-activity, B=daily-if-active-else-weekly"
+            "W=weekly-if-active, D=daily, B=daily-if-active-else-weekly"
         ),
     )
     archive_format: Optional[str] = Field(

--- a/api/tests/test_archive_command.py
+++ b/api/tests/test_archive_command.py
@@ -186,7 +186,8 @@ class TestIsUserDue:
         assert is_due is False
         assert "not yet due" in reason
 
-    def test_daily_no_new_activity_since_send(self, db):
+    def test_daily_due_after_interval_without_new_activity(self, db):
+        """D is unconditional daily: no requirement for new logs since last archive."""
         user = _make_user(db, name="daily3", archive_frequency="D")
         now = datetime.now(timezone.utc)
         sent_at = now - timedelta(days=2)
@@ -201,8 +202,8 @@ class TestIsUserDue:
         db.commit()
         _add_published_log(db, user, upd_timestamp=sent_at - timedelta(days=1))
         is_due, reason = _is_user_due(db, user, now)
-        assert is_due is False
-        assert "no new activity" in reason
+        assert is_due is True
+        assert "daily: due" in reason
 
     def test_daily_new_activity_since_send(self, db):
         user = _make_user(db, name="daily4", archive_frequency="D")


### PR DESCRIPTION
Daily (D) was incorrectly applying a new-log-activity gate like W/M/B, causing skips with daily: no new activity since last archive. D now only enforces the rolling 24h interval. B keeps daily vs weekly with the activity gate. Update schema descriptions and tests.

Made-with: Cursor