### PR TITLE
Add self-service account deletion with admin tools and backup email.

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -106,5 +106,8 @@ Working on a better nearby trigpoints page
 Started work on an analytics schema for data mining
 Added a page to compare logs for multiple users
 
+XX May 2026
 
+Frontend
+Regular archive backups of your logs by email
 

--- a/api/api/v1/endpoints/admin.py
+++ b/api/api/v1/endpoints/admin.py
@@ -22,6 +22,12 @@ from api.crud import trig_type as trig_type_crud
 from api.crud import user as user_crud
 from api.crud import user_merge as user_merge_crud
 from api.models.user import User
+from api.schemas.account_deletion import (
+    AccountDeletionEmailBackupResponse,
+    AccountDeletionExecuteRequest,
+    AccountDeletionExecuteResponse,
+    AccountDeletionSummaryResponse,
+)
 from api.schemas.admin import (
     AdminMergeUsersPreview,
     AdminMergeUsersRequest,
@@ -1376,6 +1382,93 @@ def merge_users_admin(
     )
 
     return response
+
+
+# ============================================================================
+# Account deletion (admin)
+# ============================================================================
+
+
+@router.get(
+    "/users/{user_id}/account-deletion/summary",
+    response_model=AccountDeletionSummaryResponse,
+    openapi_extra=openapi_lifecycle(
+        "beta",
+        note="Account deletion overview for a user selected by an administrator.",
+    ),
+)
+def admin_account_deletion_summary(
+    user_id: int,
+    admin_user: User = Depends(ADMIN_SCOPE_DEPENDENCY),
+    db: Session = Depends(get_db),
+):
+    from api.services.account_deletion_service import get_account_deletion_summary
+
+    target = db.query(User).filter(User.id == user_id).first()
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+    return get_account_deletion_summary(db, target)
+
+
+@router.post(
+    "/users/{user_id}/account-deletion/email-backup",
+    response_model=AccountDeletionEmailBackupResponse,
+    openapi_extra=openapi_lifecycle(
+        "beta",
+        note="Email the selected user a zip of their published logs before account deletion.",
+    ),
+)
+def admin_account_deletion_email_backup(
+    user_id: int,
+    admin_user: User = Depends(ADMIN_SCOPE_DEPENDENCY),
+    db: Session = Depends(get_db),
+):
+    from api.services import account_deletion_service as ads
+
+    target = db.query(User).filter(User.id == user_id).first()
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+    email_addr = str(target.email or "").strip()
+    if not email_addr:
+        raise HTTPException(
+            status_code=400,
+            detail="That user has no email address on file; a backup cannot be sent.",
+        )
+    ok = ads.send_account_deletion_log_backup_email(db, target)
+    if not ok:
+        raise HTTPException(status_code=500, detail="Could not send the backup email.")
+    return AccountDeletionEmailBackupResponse()
+
+
+@router.post(
+    "/users/{user_id}/account-deletion",
+    response_model=AccountDeletionExecuteResponse,
+    openapi_extra=openapi_lifecycle(
+        "beta", note="Execute account deletion or anonymisation for the selected user."
+    ),
+)
+def admin_account_deletion_execute(
+    user_id: int,
+    body: AccountDeletionExecuteRequest,
+    admin_user: User = Depends(ADMIN_SCOPE_DEPENDENCY),
+    db: Session = Depends(get_db),
+):
+    from api.services import account_deletion_service as ads
+
+    target = db.query(User).filter(User.id == user_id).first()
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+    try:
+        return ads.execute_account_deletion(
+            db,
+            target_user=target,
+            mode=body.mode,
+            feedback=body.feedback,
+            actor_user=admin_user,
+            is_admin_action=True,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
 
 
 # ============================================================================

--- a/api/api/v1/endpoints/users.py
+++ b/api/api/v1/endpoints/users.py
@@ -37,6 +37,12 @@ from api.models.tphoto import TPhoto
 from api.models.trig import Trig
 from api.models.trig_type import TrigCategory, TrigType
 from api.models.user import TLog, User
+from api.schemas.account_deletion import (
+    AccountDeletionEmailBackupResponse,
+    AccountDeletionExecuteRequest,
+    AccountDeletionExecuteResponse,
+    AccountDeletionSummaryResponse,
+)
 from api.schemas.area import (
     AreaCountItem,
     AreaTypeResponse,
@@ -803,6 +809,85 @@ def send_archive_now(
         "zip_size_bytes": len(zip_bytes),
         "format": archive_format,
     }
+
+
+@router.get(
+    "/me/account-deletion/summary",
+    response_model=AccountDeletionSummaryResponse,
+    openapi_extra=openapi_lifecycle(
+        "beta",
+        note="Username, email, and activity counts for the account deletion page.",
+    ),
+)
+def account_deletion_summary_me(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    from api.services.account_deletion_service import get_account_deletion_summary
+
+    return get_account_deletion_summary(db, current_user)
+
+
+@router.post(
+    "/me/account-deletion/email-backup",
+    response_model=AccountDeletionEmailBackupResponse,
+    openapi_extra=openapi_lifecycle(
+        "beta",
+        note="Email a zip of published logs before account deletion (rate limited for non-admins).",
+    ),
+)
+def account_deletion_email_backup_me(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    from api.api.deps import has_scope
+    from api.services import account_deletion_service as ads
+
+    user_id = int(current_user.id)
+    token_payload = getattr(current_user, "_token_payload", None)
+    is_admin = bool(token_payload and has_scope(token_payload, "api:admin"))
+    email_addr = str(current_user.email or "").strip()
+    if not email_addr:
+        raise HTTPException(
+            status_code=400,
+            detail="No email address on your account. Add one before requesting a copy.",
+        )
+    if not ads.deletion_backup_is_allowed(db, user_id, is_admin=is_admin):
+        raise HTTPException(
+            status_code=429,
+            detail="A deletion backup email was already sent in the last 24 hours.",
+        )
+    ok = ads.send_account_deletion_log_backup_email(db, current_user)
+    if not ok:
+        raise HTTPException(status_code=500, detail="Could not send the backup email.")
+    return AccountDeletionEmailBackupResponse()
+
+
+@router.post(
+    "/me/account-deletion",
+    response_model=AccountDeletionExecuteResponse,
+    openapi_extra=openapi_lifecycle(
+        "beta", note="Permanently delete or anonymise the authenticated account."
+    ),
+)
+def account_deletion_execute_me(
+    body: AccountDeletionExecuteRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    from api.services import account_deletion_service as ads
+
+    try:
+        return ads.execute_account_deletion(
+            db,
+            target_user=current_user,
+            mode=body.mode,
+            feedback=body.feedback,
+            actor_user=current_user,
+            is_admin_action=False,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
 
 
 @router.get(

--- a/api/schemas/account_deletion.py
+++ b/api/schemas/account_deletion.py
@@ -1,0 +1,65 @@
+"""
+Schemas for account deletion (self-service and admin).
+"""
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class AccountDeletionMode(str, Enum):
+    """How to treat logs, photos, and the user row when deleting an account."""
+
+    anonymise_keep_photos = "anonymise_keep_photos"
+    anonymise_delete_photos = "anonymise_delete_photos"
+    purge_all = "purge_all"
+
+
+class AccountDeletionSummaryResponse(BaseModel):
+    """Overview for the account deletion confirmation page."""
+
+    user_id: int
+    username: str
+    full_name: str = ""
+    email: str
+    log_count: int
+    photo_count: int
+
+
+class AccountDeletionExecuteRequest(BaseModel):
+    """Execute account deletion with the chosen data policy."""
+
+    mode: AccountDeletionMode
+    feedback: Optional[str] = Field(
+        default=None,
+        max_length=8000,
+        description="Optional reason for leaving (sent to operations only).",
+    )
+
+
+class AccountDeletionExecuteResponse(BaseModel):
+    """Outcome of a completed account deletion."""
+
+    success: bool = True
+    mode: AccountDeletionMode
+    user_id: int
+    previous_username: str
+    new_username: Optional[str] = Field(
+        default=None,
+        description="Set when the account was anonymised in place.",
+    )
+    logs_anonymised: int = 0
+    photos_deleted: int = 0
+    logs_deleted: int = 0
+    s3_photo_delete_failures: int = 0
+    user_row_deleted: bool = False
+
+
+class AccountDeletionEmailBackupResponse(BaseModel):
+    """Acknowledgement after queuing a pre-deletion log archive email."""
+
+    success: bool = True
+    message: str = (
+        "If your account has a valid email, you will receive a zip archive shortly."
+    )

--- a/api/services/account_deletion_service.py
+++ b/api/services/account_deletion_service.py
@@ -1,0 +1,444 @@
+"""
+Orchestration for account deletion and anonymisation (user or admin initiated).
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime, timedelta
+from typing import Optional, Tuple
+
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from api.core.logging import get_logger
+from api.models.tphoto import TPhoto
+from api.models.user import TLog, TPhotoVote, User, UserArchive
+from api.schemas.account_deletion import (
+    AccountDeletionExecuteResponse,
+    AccountDeletionMode,
+    AccountDeletionSummaryResponse,
+)
+from api.services.auth0_service import auth0_service
+from api.services.avatar_service import AvatarService
+from api.services.cache_invalidator import invalidate_user_caches
+from api.services.email_service import email_service
+from api.services.s3_service import S3Service
+
+logger = get_logger(__name__)
+
+DELETION_BACKUP_FORMAT_FLAG = "D"
+
+
+def get_account_deletion_summary(
+    db: Session, user: User
+) -> AccountDeletionSummaryResponse:
+    """Build overview counts for the deletion confirmation UI."""
+    user_id = int(user.id)
+    log_count = (
+        db.query(func.count(TLog.id)).filter(TLog.user_id == user_id).scalar() or 0
+    )
+    photo_count = (
+        db.query(func.count(TPhoto.id))
+        .join(TLog, TPhoto.tlog_id == TLog.id)
+        .filter(TLog.user_id == user_id, TPhoto.deleted_ind != "Y")
+        .scalar()
+        or 0
+    )
+    fn = str(user.firstname or "").strip()
+    sn = str(user.surname or "").strip()
+    full_name = " ".join(p for p in (fn, sn) if p)
+    return AccountDeletionSummaryResponse(
+        user_id=user_id,
+        username=str(user.name or ""),
+        full_name=full_name,
+        email=str(user.email or ""),
+        log_count=int(log_count),
+        photo_count=int(photo_count),
+    )
+
+
+def _pick_deleted_username(db: Session) -> str:
+    """Return a unique username ``Deleted-XXXXXX`` (six digits)."""
+    for _ in range(100):
+        suffix = f"{secrets.randbelow(1_000_000):06d}"
+        candidate = f"Deleted-{suffix}"
+        exists = db.query(User.id).filter(User.name == candidate).first()
+        if not exists:
+            return candidate
+    raise RuntimeError("Could not allocate a unique anonymised username")
+
+
+def _collect_active_photo_ids_for_user(db: Session, user_id: int) -> list[int]:
+    rows = (
+        db.query(TPhoto.id)
+        .join(TLog, TPhoto.tlog_id == TLog.id)
+        .filter(TLog.user_id == user_id, TPhoto.deleted_ind != "Y")
+        .order_by(TPhoto.id)
+        .all()
+    )
+    return [int(r[0]) for r in rows]
+
+
+def _collect_log_ids_for_user(db: Session, user_id: int) -> list[int]:
+    rows = db.query(TLog.id).filter(TLog.user_id == user_id).order_by(TLog.id).all()
+    return [int(r[0]) for r in rows]
+
+
+def _hard_delete_photos_by_ids(
+    db: Session, s3: S3Service, photo_ids: list[int]
+) -> Tuple[int, int]:
+    """
+    Hard-delete photos: S3 first, then DB via existing CRUD.
+
+    Returns (deleted_count, s3_failure_count).
+    """
+    from api.crud import tphoto as tphoto_crud
+
+    deleted = 0
+    s3_failures = 0
+    for pid in photo_ids:
+        if not s3.delete_photo_and_thumbnail(pid):
+            s3_failures += 1
+        if tphoto_crud.delete_photo(db, photo_id=pid, soft=False):
+            deleted += 1
+    return deleted, s3_failures
+
+
+def _purge_user_logs_and_photos(
+    db: Session, s3: S3Service, user_id: int
+) -> Tuple[int, int, int]:
+    """
+    Delete all photos (S3 + DB) and hard-delete all logs for the user.
+
+    Returns (logs_deleted, photos_deleted, s3_failures).
+    """
+    from api.crud import tlog as tlog_crud
+
+    log_ids = _collect_log_ids_for_user(db, user_id)
+    photos_deleted = 0
+    s3_failures = 0
+    for log_id in log_ids:
+        photo_ids = (
+            db.query(TPhoto.id)
+            .filter(TPhoto.tlog_id == log_id, TPhoto.deleted_ind != "Y")
+            .order_by(TPhoto.id)
+            .all()
+        )
+        pids = [int(r[0]) for r in photo_ids]
+        pd, sf = _hard_delete_photos_by_ids(db, s3, pids)
+        photos_deleted += pd
+        s3_failures += sf
+        tlog_crud.delete_log_hard(db, log_id=log_id)
+    return len(log_ids), photos_deleted, s3_failures
+
+
+def _send_ops_email(
+    *,
+    target_user_id: int,
+    previous_username: str,
+    previous_email: str,
+    mode: AccountDeletionMode,
+    feedback: Optional[str],
+    actor_label: str,
+    details_lines: list[str],
+) -> None:
+    body_lines = [
+        "Account deletion report",
+        "",
+        f"Target user id: {target_user_id}",
+        f"Previous username: {previous_username}",
+        f"Previous email (if any): {previous_email}",
+        f"Mode: {mode.value}",
+        f"Actor: {actor_label}",
+        f"Time (UTC): {datetime.now(UTC).isoformat()}",
+        "",
+        "Details:",
+        *details_lines,
+        "",
+    ]
+    if feedback and feedback.strip():
+        body_lines.extend(["Feedback from user:", feedback.strip(), ""])
+
+    message = "\n".join(body_lines)
+    reply_to = (
+        previous_email.strip() if previous_email.strip() else "contact@trigpointing.uk"
+    )
+    ok = email_service.send_contact_email(
+        to_email="trigpointing@teasel.org",
+        reply_to=reply_to,
+        subject=f"Account deletion: {previous_username} (user {target_user_id})",
+        message=message,
+        name="TrigpointingUK account system",
+        user_id=target_user_id,
+        username=previous_username,
+    )
+    if not ok:
+        logger.error(
+            "Failed to send account deletion ops email",
+            extra={"target_user_id": target_user_id},
+        )
+
+
+def execute_account_deletion(
+    db: Session,
+    *,
+    target_user: User,
+    mode: AccountDeletionMode,
+    feedback: Optional[str],
+    actor_user: User,
+    is_admin_action: bool,
+) -> AccountDeletionExecuteResponse:
+    """
+    Apply the chosen deletion policy.
+
+    Auth0 is removed before anonymising local rows (when keeping a placeholder user).
+    For full purge, the database user is removed first, then Auth0.
+    """
+    s3 = S3Service()
+    avatar = AvatarService()
+
+    user_id = int(target_user.id)
+    previous_username = str(target_user.name or "")
+    previous_email = str(target_user.email or "")
+    auth0_id = (
+        str(target_user.auth0_user_id).strip() if target_user.auth0_user_id else None
+    )
+
+    actor_label = (
+        f"admin user_id={int(actor_user.id)}"
+        if is_admin_action
+        else f"self user_id={int(actor_user.id)}"
+    )
+
+    if mode == AccountDeletionMode.purge_all:
+        logs_deleted, photos_deleted, s3_failures = _purge_user_logs_and_photos(
+            db, s3, user_id
+        )
+        db.query(TPhotoVote).filter(TPhotoVote.user_id == user_id).delete(
+            synchronize_session=False
+        )
+        db.query(User).filter(User.id == user_id).delete(synchronize_session=False)
+        db.commit()
+
+        if auth0_id and not auth0_service.delete_user(auth0_id):
+            logger.warning(
+                "Auth0 delete failed after user purge (database user already removed)",
+                extra={"auth0_user_id": auth0_id, "user_id": user_id},
+            )
+
+        invalidate_user_caches(user_id=user_id)
+        invalidate_user_caches()
+
+        details = [
+            "User row deleted: yes",
+            f"Logs deleted: {logs_deleted}",
+            f"Photos deleted: {photos_deleted}",
+            f"S3 photo delete failures: {s3_failures}",
+        ]
+        _send_ops_email(
+            target_user_id=user_id,
+            previous_username=previous_username,
+            previous_email=previous_email,
+            mode=mode,
+            feedback=feedback,
+            actor_label=actor_label,
+            details_lines=details,
+        )
+
+        return AccountDeletionExecuteResponse(
+            mode=mode,
+            user_id=user_id,
+            previous_username=previous_username,
+            new_username=None,
+            logs_anonymised=0,
+            photos_deleted=photos_deleted,
+            logs_deleted=logs_deleted,
+            s3_photo_delete_failures=s3_failures,
+            user_row_deleted=True,
+        )
+
+    # Anonymise paths: remove Auth0 first so we do not commit DB changes if IdP removal fails.
+    if auth0_id and not auth0_service.delete_user(auth0_id):
+        logger.error(
+            "Auth0 user delete failed; aborting account anonymisation",
+            extra={"auth0_user_id": auth0_id, "user_id": user_id},
+        )
+        raise RuntimeError(
+            "Could not remove the login profile from Auth0. No changes were made."
+        )
+
+    photos_deleted = 0
+    s3_failures = 0
+
+    if mode == AccountDeletionMode.anonymise_delete_photos:
+        photo_ids = _collect_active_photo_ids_for_user(db, user_id)
+        photos_deleted, s3_failures = _hard_delete_photos_by_ids(db, s3, photo_ids)
+
+    new_name_final = ""
+    for attempt in range(100):
+        candidate = _pick_deleted_username(db)
+        try:
+            u = db.query(User).filter(User.id == user_id).with_for_update().one()
+            u.name = candidate  # type: ignore[assignment]
+            u.firstname = ""  # type: ignore[assignment]
+            u.surname = ""  # type: ignore[assignment]
+            u.email = ""  # type: ignore[assignment]
+            u.homepage = ""  # type: ignore[assignment]
+            u.about = ""  # type: ignore[assignment]
+            u.cryptpw = ""  # type: ignore[assignment]
+            u.auth0_user_id = None  # type: ignore[assignment]
+            u.email_valid = "N"  # type: ignore[assignment]
+            u.email_ind = "N"  # type: ignore[assignment]
+            u.has_avatar = False  # type: ignore[assignment]
+            u.ui_prefs = {}  # type: ignore[assignment]
+            u.archive_frequency = "N"  # type: ignore[assignment]
+            db.query(TLog).filter(TLog.user_id == user_id).update(
+                {TLog.ip_addr: None}, synchronize_session=False
+            )
+            db.commit()
+            new_name_final = candidate
+            break
+        except IntegrityError:
+            db.rollback()
+            logger.warning(
+                "Anonymised username collision; retrying",
+                extra={"attempt": attempt, "candidate": candidate, "user_id": user_id},
+            )
+    else:
+        raise RuntimeError(
+            "Failed to anonymise user after repeated username collisions"
+        )
+
+    try:
+        avatar.delete(user_id)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "Avatar delete failed during anonymisation", extra={"error": str(exc)}
+        )
+
+    logs_anonymised = (
+        db.query(func.count(TLog.id)).filter(TLog.user_id == user_id).scalar() or 0
+    )
+
+    invalidate_user_caches(user_id=user_id)
+    invalidate_user_caches()
+
+    details = [
+        "User row deleted: no",
+        f"New username: {new_name_final}",
+        f"Logs retained with ip_addr cleared: {int(logs_anonymised)}",
+        f"Photos deleted: {photos_deleted}",
+        f"S3 photo delete failures: {s3_failures}",
+    ]
+    _send_ops_email(
+        target_user_id=user_id,
+        previous_username=previous_username,
+        previous_email=previous_email,
+        mode=mode,
+        feedback=feedback,
+        actor_label=actor_label,
+        details_lines=details,
+    )
+
+    return AccountDeletionExecuteResponse(
+        mode=mode,
+        user_id=user_id,
+        previous_username=previous_username,
+        new_username=new_name_final,
+        logs_anonymised=int(logs_anonymised),
+        photos_deleted=photos_deleted,
+        logs_deleted=0,
+        s3_photo_delete_failures=s3_failures,
+        user_row_deleted=False,
+    )
+
+
+def deletion_backup_is_allowed(db: Session, user_id: int, *, is_admin: bool) -> bool:
+    """Return False when a non-admin user has already received a deletion backup in 24 hours."""
+    if is_admin:
+        return True
+    cutoff = datetime.now(UTC) - timedelta(hours=24)
+    recent = (
+        db.query(UserArchive.id)
+        .filter(
+            UserArchive.user_id == user_id,
+            UserArchive.status == "S",
+            UserArchive.format_at_send == DELETION_BACKUP_FORMAT_FLAG,
+            UserArchive.created_at >= cutoff,
+        )
+        .first()
+    )
+    return recent is None
+
+
+def send_account_deletion_log_backup_email(db: Session, user: User) -> bool:
+    """
+    Build a published-log zip for ``user`` and email it; record ``user_archive`` for auditing.
+
+    Returns True if the email was accepted by SES. Caller should enforce rate limits.
+    """
+    from api.services.archive_service import generate_archive_zip
+
+    user_id = int(user.id)
+    email_addr = str(user.email or "").strip()
+    if not email_addr:
+        return False
+
+    archive_format = str(user.archive_format or "R")
+    try:
+        zip_bytes = generate_archive_zip(db, user, archive_format)
+    except Exception as exc:
+        logger.error(
+            "Deletion backup zip generation failed",
+            extra={"user_id": user_id, "error": str(exc)},
+        )
+        db.add(
+            UserArchive(
+                user_id=user_id,
+                status="F",
+                frequency_at_send="N",
+                format_at_send=DELETION_BACKUP_FORMAT_FLAG,
+                error_message=str(exc)[:2000],
+            )
+        )
+        db.commit()
+        return False
+
+    log_count = (
+        db.query(func.count(TLog.id))
+        .filter(TLog.user_id == user_id, TLog.status == "P")
+        .scalar()
+        or 0
+    )
+    username = str(user.name or f"user_{user_id}")
+    ts = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    filename = f"trigpointinguk_{username}_{ts}_pre_deletion.zip"
+
+    fn = (str(user.firstname).strip() if user.firstname else None) or None  # type: ignore[arg-type]
+    sn = (str(user.surname).strip() if user.surname else None) or None  # type: ignore[arg-type]
+
+    ok = email_service.send_deletion_backup_email(
+        to_email=email_addr,
+        username=username,
+        zip_bytes=zip_bytes,
+        filename=filename,
+        log_count=int(log_count),
+        user_id=user_id,
+        firstname=fn,
+        surname=sn,
+    )
+    db.add(
+        UserArchive(
+            user_id=user_id,
+            status="S" if ok else "F",
+            frequency_at_send="N",
+            format_at_send=DELETION_BACKUP_FORMAT_FLAG,
+            log_count=int(log_count),
+            file_size_bytes=len(zip_bytes) if ok else None,
+            error_message=None if ok else "Email send failed",
+        )
+    )
+    db.commit()
+    return ok

--- a/api/services/email_service.py
+++ b/api/services/email_service.py
@@ -383,6 +383,122 @@ class EmailService:
             )
             return False
 
+    def send_deletion_backup_email(
+        self,
+        to_email: str,
+        username: str,
+        zip_bytes: bytes,
+        filename: str,
+        log_count: int,
+        user_id: Optional[int] = None,
+        firstname: Optional[str] = None,
+        surname: Optional[str] = None,
+    ) -> bool:
+        """
+        Email a one-off log archive before account deletion (distinct copy from routine archives).
+
+        In non-production environments, the recipient is overridden to test@teasel.org
+        (same behaviour as routine archive emails).
+        """
+        from api.core.config import settings
+
+        if not self.ses_client:
+            logger.error("SES client not available")
+            return False
+
+        actual_recipient = to_email
+        if settings.ENVIRONMENT != "production":
+            actual_recipient = "test@teasel.org"
+            logger.info(
+                json.dumps(
+                    {
+                        "event": "deletion_backup_email_recipient_override",
+                        "original_recipient": to_email,
+                        "actual_recipient": actual_recipient,
+                        "environment": settings.ENVIRONMENT,
+                        "user_id": user_id,
+                    }
+                )
+            )
+
+        display_name = _build_display_name(firstname, surname, username)
+
+        msg = MIMEMultipart("mixed")
+        msg["Subject"] = (
+            f"TrigpointingUK: your logs before account deletion ({username})"
+        )
+        msg["From"] = self.from_email
+        msg["To"] = actual_recipient
+
+        body_html = (
+            f"<html><body>"
+            f"<p>Hello {display_name},</p>"
+            f"<p>You asked for a copy of your logs before deleting your TrigpointingUK account.</p>"
+            f"<p>Attached is a zip archive containing <strong>{log_count}</strong> published log(s), "
+            f"generated at the time you clicked the button.</p>"
+            f"<p>Thank you for having been part of the community.</p>"
+            f"<p>— TrigpointingUK</p>"
+            f"</body></html>"
+        )
+        body_part = MIMEText(body_html, "html", "utf-8")
+        msg.attach(body_part)
+
+        attachment = MIMEApplication(zip_bytes, "zip")
+        attachment.add_header("Content-Disposition", "attachment", filename=filename)
+        msg.attach(attachment)
+
+        try:
+            response = self.ses_client.send_raw_email(
+                Source=self.from_email,
+                Destinations=[actual_recipient],
+                RawMessage={"Data": msg.as_string()},
+            )
+
+            logger.info(
+                json.dumps(
+                    {
+                        "event": "deletion_backup_email_sent",
+                        "to": actual_recipient,
+                        "original_to": to_email,
+                        "message_id": response.get("MessageId", ""),
+                        "username": username,
+                        "user_id": user_id,
+                        "zip_size_bytes": len(zip_bytes),
+                        "log_count": log_count,
+                    }
+                )
+            )
+            return True
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            error_message = e.response.get("Error", {}).get("Message", str(e))
+            logger.error(
+                json.dumps(
+                    {
+                        "event": "deletion_backup_email_failed",
+                        "to": actual_recipient,
+                        "error_code": error_code,
+                        "error_message": error_message,
+                        "user_id": user_id,
+                    }
+                )
+            )
+            return False
+
+        except Exception as e:
+            logger.error(
+                json.dumps(
+                    {
+                        "event": "deletion_backup_email_error",
+                        "to": actual_recipient,
+                        "error": str(e),
+                        "user_id": user_id,
+                    }
+                )
+            )
+            return False
+
 
 # Singleton instance
 email_service = EmailService()

--- a/api/tests/test_account_deletion.py
+++ b/api/tests/test_account_deletion.py
@@ -1,0 +1,315 @@
+"""
+Integration tests for account deletion and anonymisation endpoints.
+"""
+
+import uuid
+from datetime import date, datetime
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from api.models.tphoto import TPhoto
+from api.models.user import TLog, User
+
+
+def _make_mapped_user(db: Session, make_user):
+    suffix = uuid.uuid4().hex[:8]
+    user = make_user(
+        name=f"acctdel_{suffix}",
+        email=f"{suffix}@example.com",
+        auth0_user_id=None,
+    )
+    user.auth0_user_id = f"auth0|{user.id}"
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _add_log(db: Session, user: User, trig) -> TLog:
+    log = TLog(
+        trig_id=trig.id,
+        user_id=user.id,
+        comment="Keep me",
+        condition="G",
+        date=date.today(),
+        time=datetime.now().time(),
+        osgb_eastings=1,
+        osgb_northings=1,
+        osgb_gridref="AA 00000 00000",
+        fb_number="",
+        score=0,
+        ip_addr="192.168.1.1",
+        source="W",
+        status="P",
+    )
+    db.add(log)
+    db.commit()
+    db.refresh(log)
+    return log
+
+
+def _add_photo(db: Session, log: TLog) -> TPhoto:
+    photo = TPhoto(
+        tlog_id=log.id,
+        server_id=1,
+        type="T",
+        filename="000/P00001.jpg",
+        filesize=100,
+        height=100,
+        width=100,
+        icon_filename="000/I00001.jpg",
+        icon_filesize=10,
+        icon_height=10,
+        icon_width=10,
+        name="Test Photo",
+        text_desc="Test",
+        ip_addr="127.0.0.1",
+        public_ind="Y",
+        deleted_ind="N",
+        source="W",
+        crt_timestamp=datetime.now(),
+    )
+    db.add(photo)
+    db.commit()
+    db.refresh(photo)
+    return photo
+
+
+def test_me_summary_unauthenticated(client: TestClient):
+    r = client.get("/v1/users/me/account-deletion/summary")
+    assert r.status_code == 401
+
+
+def test_me_summary_ok(client: TestClient, db: Session, make_user, test_trig):
+    user = _make_mapped_user(db, make_user)
+    _add_log(db, user, test_trig)
+    r = client.get(
+        "/v1/users/me/account-deletion/summary",
+        headers={"Authorization": f"Bearer auth0_user_{user.id}"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["user_id"] == user.id
+    assert body["username"] == user.name
+    assert body["full_name"] == "Test User"
+    assert body["log_count"] >= 1
+
+
+@patch(
+    "api.services.account_deletion_service.email_service.send_contact_email",
+    return_value=True,
+)
+@patch(
+    "api.services.account_deletion_service.auth0_service.delete_user",
+    return_value=True,
+)
+@patch("api.services.account_deletion_service.AvatarService.delete", return_value=True)
+def test_me_execute_anonymise_keep_photos(
+    _mock_avatar,
+    _mock_auth0,
+    _mock_email,
+    client: TestClient,
+    db: Session,
+    make_user,
+    test_trig,
+):
+    user = _make_mapped_user(db, make_user)
+    log = _add_log(db, user, test_trig)
+
+    r = client.post(
+        "/v1/users/me/account-deletion",
+        headers={"Authorization": f"Bearer auth0_user_{user.id}"},
+        json={"mode": "anonymise_keep_photos", "feedback": "Moving abroad"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["user_row_deleted"] is False
+    assert data["new_username"].startswith("Deleted-")
+
+    db.expire_all()
+    u = db.query(User).filter(User.id == user.id).one()
+    assert u.name.startswith("Deleted-")
+    assert (u.email or "") == ""
+    assert u.auth0_user_id is None
+    log2 = db.query(TLog).filter(TLog.id == log.id).one()
+    assert log2.ip_addr is None
+
+
+@patch(
+    "api.services.account_deletion_service.email_service.send_contact_email",
+    return_value=True,
+)
+@patch(
+    "api.services.account_deletion_service.auth0_service.delete_user",
+    return_value=True,
+)
+@patch(
+    "api.services.account_deletion_service.S3Service.delete_photo_and_thumbnail",
+    return_value=True,
+)
+@patch("api.services.account_deletion_service.AvatarService.delete", return_value=True)
+def test_me_execute_anonymise_delete_photos(
+    _mock_avatar,
+    _mock_s3,
+    _mock_auth0,
+    _mock_email,
+    client: TestClient,
+    db: Session,
+    make_user,
+    test_trig,
+):
+    user = _make_mapped_user(db, make_user)
+    log = _add_log(db, user, test_trig)
+    _add_photo(db, log)
+
+    r = client.post(
+        "/v1/users/me/account-deletion",
+        headers={"Authorization": f"Bearer auth0_user_{user.id}"},
+        json={"mode": "anonymise_delete_photos"},
+    )
+    assert r.status_code == 200
+    assert r.json()["photos_deleted"] >= 1
+    assert db.query(TPhoto).filter(TPhoto.tlog_id == log.id).count() == 0
+
+
+@patch(
+    "api.services.account_deletion_service.email_service.send_contact_email",
+    return_value=True,
+)
+@patch(
+    "api.services.account_deletion_service.auth0_service.delete_user",
+    return_value=True,
+)
+@patch(
+    "api.services.account_deletion_service.S3Service.delete_photo_and_thumbnail",
+    return_value=True,
+)
+def test_me_execute_purge_all(
+    _mock_s3,
+    _mock_auth0,
+    _mock_email,
+    client: TestClient,
+    db: Session,
+    make_user,
+    test_trig,
+):
+    user = _make_mapped_user(db, make_user)
+    log = _add_log(db, user, test_trig)
+    _add_photo(db, log)
+    user_pk = int(user.id)
+    log_pk = int(log.id)
+
+    r = client.post(
+        "/v1/users/me/account-deletion",
+        headers={"Authorization": f"Bearer auth0_user_{user_pk}"},
+        json={"mode": "purge_all"},
+    )
+    assert r.status_code == 200
+    assert r.json()["user_row_deleted"] is True
+    assert db.query(User).filter(User.id == user_pk).first() is None
+    assert db.query(TLog).filter(TLog.id == log_pk).first() is None
+
+
+@patch(
+    "api.services.account_deletion_service.auth0_service.delete_user",
+    return_value=False,
+)
+def test_me_execute_anonymise_auth0_failure_returns_502(
+    _mock_auth0,
+    client: TestClient,
+    db: Session,
+    make_user,
+    test_trig,
+):
+    user = _make_mapped_user(db, make_user)
+    _add_log(db, user, test_trig)
+
+    r = client.post(
+        "/v1/users/me/account-deletion",
+        headers={"Authorization": f"Bearer auth0_user_{user.id}"},
+        json={"mode": "anonymise_keep_photos"},
+    )
+    assert r.status_code == 502
+    u = db.query(User).filter(User.id == user.id).one()
+    assert not str(u.name).startswith("Deleted-")
+
+
+def test_admin_summary_not_found(client: TestClient, make_user):
+    # Admin token resolves to the first user row; ensure one exists.
+    make_user()
+    r = client.get(
+        "/v1/admin/users/999999999/account-deletion/summary",
+        headers={"Authorization": "Bearer auth0_admin"},
+    )
+    assert r.status_code == 404
+
+
+def test_admin_summary_ok(client: TestClient, db: Session, make_user, test_trig):
+    user = _make_mapped_user(db, make_user)
+    _add_log(db, user, test_trig)
+    r = client.get(
+        f"/v1/admin/users/{user.id}/account-deletion/summary",
+        headers={"Authorization": "Bearer auth0_admin"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["user_id"] == user.id
+    assert body["full_name"] == "Test User"
+
+
+@patch(
+    "api.services.account_deletion_service.email_service.send_contact_email",
+    return_value=True,
+)
+@patch(
+    "api.services.account_deletion_service.auth0_service.delete_user",
+    return_value=True,
+)
+@patch("api.services.account_deletion_service.AvatarService.delete", return_value=True)
+def test_admin_execute_purge_target(
+    _mock_avatar,
+    _mock_auth0,
+    _mock_email,
+    client: TestClient,
+    db: Session,
+    make_user,
+    test_trig,
+):
+    victim = _make_mapped_user(db, make_user)
+    log = _add_log(db, victim, test_trig)
+    victim_id = int(victim.id)
+    log_pk = int(log.id)
+
+    r = client.post(
+        f"/v1/admin/users/{victim_id}/account-deletion",
+        headers={"Authorization": "Bearer auth0_admin"},
+        json={"mode": "purge_all", "feedback": "Spam account"},
+    )
+    assert r.status_code == 200
+    assert db.query(User).filter(User.id == victim_id).first() is None
+    assert db.query(TLog).filter(TLog.id == log_pk).first() is None
+
+
+@patch("api.services.archive_service.generate_archive_zip", return_value=b"ZIP")
+@patch(
+    "api.services.email_service.email_service.send_deletion_backup_email",
+    return_value=True,
+)
+def test_me_deletion_email_backup(
+    _mock_send,
+    _mock_zip,
+    client: TestClient,
+    db: Session,
+    make_user,
+    test_trig,
+):
+    user = _make_mapped_user(db, make_user)
+    _add_log(db, user, test_trig)
+
+    r = client.post(
+        "/v1/users/me/account-deletion/email-backup",
+        headers={"Authorization": f"Bearer auth0_user_{user.id}"},
+    )
+    assert r.status_code == 200

--- a/docs/Manually_running_archive_job.md
+++ b/docs/Manually_running_archive_job.md
@@ -1,0 +1,5 @@
+# Maually Running Archive Job
+
+```bash
+aws ecs run-task   --region eu-west-1   --cluster trigpointing-cluster   --task-definition trigpointing-archive   --launch-type FARGATE   --platform-version LATEST   --network-configuration 'awsvpcConfiguration={subnets=[subnet-01e6a0c671672b2b8,subnet-03d8491f3d39e497d],securityGroups=[sg-08b7e24bcfc59886d],assignPublicIp=DISABLED}'   --started-by cli-manual-archive
+```

--- a/web/src/components/archive/ArchivePreferencesPanel.tsx
+++ b/web/src/components/archive/ArchivePreferencesPanel.tsx
@@ -237,8 +237,8 @@ export default function ArchivePreferencesPanel({
           {sending ? "Sending…" : "Send archive now"}
         </button>
         <span className="text-xs text-gray-500 dark:text-gray-400">
-          Sends an immediate archive to your registered email (at most once per format
-          every 24 hours).
+          Sends an immediate archive to your registered email (max one per format
+          per day).
         </span>
       </div>
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -579,6 +579,101 @@ export async function migrateLegacyUser(
   );
 }
 
+export type AccountDeletionMode =
+  | "anonymise_keep_photos"
+  | "anonymise_delete_photos"
+  | "purge_all";
+
+export interface AccountDeletionSummary {
+  user_id: number;
+  username: string;
+  full_name: string;
+  email: string;
+  log_count: number;
+  photo_count: number;
+}
+
+export interface AccountDeletionEmailBackupResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface AccountDeletionExecuteResponse {
+  success: boolean;
+  mode: AccountDeletionMode;
+  user_id: number;
+  previous_username: string;
+  new_username?: string | null;
+  logs_anonymised: number;
+  photos_deleted: number;
+  logs_deleted: number;
+  s3_photo_delete_failures: number;
+  user_row_deleted: boolean;
+}
+
+export async function fetchAccountDeletionSummaryMe(
+  token: string
+): Promise<AccountDeletionSummary> {
+  return apiGet<AccountDeletionSummary>(
+    "/v1/users/me/account-deletion/summary",
+    token
+  );
+}
+
+export async function postAccountDeletionEmailBackupMe(
+  token: string
+): Promise<AccountDeletionEmailBackupResponse> {
+  return apiPost<AccountDeletionEmailBackupResponse>(
+    "/v1/users/me/account-deletion/email-backup",
+    {},
+    token
+  );
+}
+
+export async function executeAccountDeletionMe(
+  payload: { mode: AccountDeletionMode; feedback?: string | null },
+  token: string
+): Promise<AccountDeletionExecuteResponse> {
+  return apiPost<AccountDeletionExecuteResponse>(
+    "/v1/users/me/account-deletion",
+    payload,
+    token
+  );
+}
+
+export async function fetchAdminAccountDeletionSummary(
+  userId: number,
+  token: string
+): Promise<AccountDeletionSummary> {
+  return apiGet<AccountDeletionSummary>(
+    `/v1/admin/users/${userId}/account-deletion/summary`,
+    token
+  );
+}
+
+export async function postAdminAccountDeletionEmailBackup(
+  userId: number,
+  token: string
+): Promise<AccountDeletionEmailBackupResponse> {
+  return apiPost<AccountDeletionEmailBackupResponse>(
+    `/v1/admin/users/${userId}/account-deletion/email-backup`,
+    {},
+    token
+  );
+}
+
+export async function executeAdminAccountDeletion(
+  userId: number,
+  payload: { mode: AccountDeletionMode; feedback?: string | null },
+  token: string
+): Promise<AccountDeletionExecuteResponse> {
+  return apiPost<AccountDeletionExecuteResponse>(
+    `/v1/admin/users/${userId}/account-deletion`,
+    payload,
+    token
+  );
+}
+
 // Admin Trigpoint Management Types and Functions
 
 export interface TrigNeedsAttentionSummary {

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -26,6 +26,7 @@ const Map = lazy(() => import("./routes/Map"));
 const Search = lazy(() => import("./routes/Search"));
 const LegacyMigration = lazy(() => import("./routes/LegacyMigration"));
 const Contact = lazy(() => import("./routes/Contact"));
+const AccountDeletion = lazy(() => import("./routes/AccountDeletion"));
 const Attributions = lazy(() => import("./routes/Attributions"));
 const Admin = lazy(() => import("./routes/Admin"));
 const AdminNeedsAttention = lazy(() => import("./routes/admin/NeedsAttention"));
@@ -132,6 +133,7 @@ const router = createBrowserRouter(
         { path: "/profile/:userId/photos", element: <UserPhotos /> },
         { path: "/profile", element: <UserProfile /> },
         { path: "/preferences", element: <Preferences /> },
+        { path: "/account/delete", element: <AccountDeletion /> },
         { path: "/lists", element: <TrigLists /> },
         { path: "/lists/:listId", element: <TrigLists /> },
         { path: "/settings", element: <Navigate to="/preferences" replace /> },

--- a/web/src/routes/AccountDeletion.tsx
+++ b/web/src/routes/AccountDeletion.tsx
@@ -1,0 +1,436 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import toast from "react-hot-toast";
+
+import AlertDialog from "../components/ui/AlertDialog";
+import Button from "../components/ui/Button";
+import Card from "../components/ui/Card";
+import Spinner from "../components/ui/Spinner";
+import Textarea from "../components/ui/Textarea";
+import {
+  type AccountDeletionMode,
+  type AccountDeletionSummary,
+  executeAccountDeletionMe,
+  executeAdminAccountDeletion,
+  fetchAccountDeletionSummaryMe,
+  fetchAdminAccountDeletionSummary,
+  postAccountDeletionEmailBackupMe,
+  postAdminAccountDeletionEmailBackup,
+} from "../lib/api";
+
+const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE as string | undefined;
+const BASE_SCOPES = "openid profile email api:write api:read-pii offline_access";
+const ADMIN_SCOPE = "api:admin";
+const ADMIN_AUTH_PARAMS: { scope: string; audience?: string } = AUTH0_AUDIENCE
+  ? { audience: AUTH0_AUDIENCE, scope: `${BASE_SCOPES} ${ADMIN_SCOPE}` }
+  : { scope: `${BASE_SCOPES} ${ADMIN_SCOPE}` };
+
+const MODE_OPTIONS: {
+  id: AccountDeletionMode;
+  title: string;
+  body: string;
+}[] = [
+  {
+    id: "anonymise_keep_photos",
+    title: "Keep my logs and photos, anonymised",
+    body: "Your visits and photos stay on TrigpointingUK under a placeholder name. Personal details and login are removed.",
+  },
+  {
+    id: "anonymise_delete_photos",
+    title: "Keep my logs anonymised, delete all photos",
+    body: "Logs remain (anonymised); all of your photos are removed from the site and from storage.",
+  },
+  {
+    id: "purge_all",
+    title: "Delete all my logs and photos",
+    body: "Everything you logged and every photo you uploaded is permanently removed. Your account record is deleted.",
+  },
+];
+
+export default function AccountDeletion() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const {
+    isAuthenticated,
+    isLoading: isAuth0Loading,
+    user: auth0User,
+    getAccessTokenSilently,
+    logout,
+    loginWithRedirect,
+  } = useAuth0();
+
+  const userRoles =
+    (auth0User?.["https://trigpointing.uk/roles"] as string[]) || [];
+  const hasAdminRole = userRoles.includes("api-admin");
+
+  const adminTargetUserId = useMemo(() => {
+    const raw = searchParams.get("userId")?.trim();
+    if (!raw || !/^\d+$/.test(raw)) return null;
+    return Number(raw);
+  }, [searchParams]);
+
+  const isAdminContext = adminTargetUserId != null;
+
+  const [summary, setSummary] = useState<AccountDeletionSummary | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadingSummary, setLoadingSummary] = useState(false);
+  const [mode, setMode] = useState<AccountDeletionMode>("anonymise_keep_photos");
+  const [feedback, setFeedback] = useState("");
+  const [emailBackupBusy, setEmailBackupBusy] = useState(false);
+  const [executeBusy, setExecuteBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const permissionDenied =
+    isAdminContext && !hasAdminRole && isAuthenticated;
+
+  const fetchToken = useCallback(
+    async (forAdminApi: boolean) => {
+      if (forAdminApi) {
+        return getAccessTokenSilently({
+          authorizationParams: { ...ADMIN_AUTH_PARAMS },
+        });
+      }
+      return getAccessTokenSilently();
+    },
+    [getAccessTokenSilently]
+  );
+
+  useEffect(() => {
+    if (!isAuthenticated || isAuth0Loading || permissionDenied) {
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      setLoadingSummary(true);
+      setLoadError(null);
+      try {
+        const token = await fetchToken(isAdminContext);
+        const data = isAdminContext
+          ? await fetchAdminAccountDeletionSummary(adminTargetUserId!, token)
+          : await fetchAccountDeletionSummaryMe(token);
+        if (!cancelled) {
+          setSummary(data);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setLoadError(e instanceof Error ? e.message : "Failed to load account summary");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingSummary(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    adminTargetUserId,
+    fetchToken,
+    isAdminContext,
+    isAuthenticated,
+    isAuth0Loading,
+    permissionDenied,
+  ]);
+
+  const handleEmailBackup = async () => {
+    if (!summary) return;
+    setEmailBackupBusy(true);
+    try {
+      const token = await fetchToken(isAdminContext);
+      if (isAdminContext) {
+        await postAdminAccountDeletionEmailBackup(adminTargetUserId!, token);
+      } else {
+        await postAccountDeletionEmailBackupMe(token);
+      }
+      toast.success("If your account has a valid email, you should receive a zip archive shortly.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Could not send the backup email");
+    } finally {
+      setEmailBackupBusy(false);
+    }
+  };
+
+  const runExecute = async () => {
+    if (!summary) return;
+    setExecuteBusy(true);
+    try {
+      const token = await fetchToken(isAdminContext);
+      const payload = {
+        mode,
+        feedback: feedback.trim() || null,
+      };
+      const result = isAdminContext
+        ? await executeAdminAccountDeletion(adminTargetUserId!, payload, token)
+        : await executeAccountDeletionMe(payload, token);
+
+      if (isAdminContext) {
+        toast.success("The member account has been processed.");
+        navigate("/admin");
+      } else {
+        toast.success(
+          result.user_row_deleted
+            ? "Your account and content have been removed."
+            : "Your account has been anonymised. You will be signed out."
+        );
+        await logout({
+          logoutParams: {
+            returnTo: window.location.origin,
+          },
+        });
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Account deletion failed");
+    } finally {
+      setExecuteBusy(false);
+    }
+  };
+
+  const confirmDescription = useMemo(() => {
+    const opt = MODE_OPTIONS.find((o) => o.id === mode);
+    const base = opt?.body ?? "";
+    return `${base}\n\nThis cannot be undone. Are you sure you wish to continue?`;
+  }, [mode]);
+
+  if (isAuth0Loading) {
+    return (
+      <div className="flex justify-center py-24">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <>
+        <title>Delete account | TrigpointingUK</title>
+        <div className="max-w-xl mx-auto px-4 py-12">
+          <Card>
+            <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-3">
+              Delete account
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
+              Sign in to review your account and choose how your data should be handled.
+            </p>
+            <Button
+              onClick={() =>
+                loginWithRedirect({
+                  appState: {
+                    returnTo: `${window.location.pathname}${window.location.search}`,
+                  },
+                })
+              }
+            >
+              Sign in
+            </Button>
+          </Card>
+        </div>
+      </>
+    );
+  }
+
+  if (permissionDenied) {
+    return (
+      <>
+        <title>Delete account | TrigpointingUK</title>
+        <div className="max-w-xl mx-auto px-4 py-12">
+          <Card>
+            <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-3">
+              Admin access required
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mb-4">
+              Opening the deletion flow for another user requires the api-admin role.
+            </p>
+            <Link
+              to="/account/delete"
+              className="text-trig-green-600 dark:text-trig-green-400 font-medium hover:underline"
+            >
+              Go to your own account deletion page
+            </Link>
+          </Card>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <title>Delete account | TrigpointingUK</title>
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100">
+            {isAdminContext ? "Delete or anonymise a member account" : "Delete your account"}
+          </h1>
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            {isAdminContext
+              ? "You are signed in as an administrator. Confirm the member below, choose a data option, then proceed."
+              : "We are sorry to see you go. You can choose what happens to your logs and photos, request a backup email, and leave brief feedback if you wish."}
+          </p>
+        </div>
+
+        {loadingSummary && (
+          <div className="flex justify-center py-12">
+            <Spinner size="lg" />
+          </div>
+        )}
+
+        {loadError && !loadingSummary && (
+          <Card>
+            <p className="text-red-600 dark:text-red-400">{loadError}</p>
+          </Card>
+        )}
+
+        {summary && !loadingSummary && (
+          <>
+            <Card>
+              <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-4">
+                Account overview
+              </h2>
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Username</dt>
+                  <dd className="font-medium text-gray-900 dark:text-gray-100">{summary.username}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Full Name</dt>
+                  <dd className="font-medium text-gray-900 dark:text-gray-100">
+                    {summary.full_name?.trim() ? summary.full_name : "—"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Email on file</dt>
+                  <dd className="font-medium text-gray-900 dark:text-gray-100">
+                    {summary.email?.trim() ? summary.email : "—"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Log count</dt>
+                  <dd className="font-medium text-gray-900 dark:text-gray-100">{summary.log_count}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Photo count</dt>
+                  <dd className="font-medium text-gray-900 dark:text-gray-100">{summary.photo_count}</dd>
+                </div>
+              </dl>
+            </Card>
+
+            <div>
+              <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-3">
+                What should happen to your data?
+              </h2>
+              <div className="grid grid-cols-1 gap-4">
+                {MODE_OPTIONS.map((opt) => {
+                  const selected = mode === opt.id;
+                  return (
+                    <button
+                      key={opt.id}
+                      type="button"
+                      onClick={() => setMode(opt.id)}
+                      className={`text-left rounded-lg border-2 p-4 transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-trig-green-500 ${
+                        selected
+                          ? "border-trig-green-600 bg-trig-green-50 shadow-md ring-2 ring-trig-green-500/40 dark:border-trig-green-500 dark:bg-trig-green-950 dark:shadow-md dark:ring-2 dark:ring-trig-green-400/40"
+                          : "border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-500"
+                      }`}
+                    >
+                      <div
+                        className={`font-semibold text-gray-900 ${
+                          selected ? "dark:text-gray-50" : "dark:text-gray-100"
+                        }`}
+                      >
+                        {opt.title}
+                      </div>
+                      <p
+                        className={`mt-2 text-sm text-gray-600 ${
+                          selected ? "dark:text-gray-200" : "dark:text-gray-300"
+                        }`}
+                      >
+                        {opt.body}
+                      </p>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <Card>
+              <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
+                Backup email
+              </h2>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                Email a zip copy of your published logs to the address on this account.
+              </p>
+              <Button
+                variant="secondary"
+                onClick={handleEmailBackup}
+                disabled={emailBackupBusy || !summary.email?.trim()}
+              >
+                {emailBackupBusy ? (
+                  <span className="flex items-center gap-2">
+                    <Spinner size="sm" />
+                    Sending…
+                  </span>
+                ) : (
+                  "Email me a copy of my logs before deletion"
+                )}
+              </Button>
+              {!summary.email?.trim() && (
+                <p className="mt-2 text-xs text-amber-700 dark:text-amber-400">
+                  Add an email address in preferences before you can use this option.
+                </p>
+              )}
+            </Card>
+
+            <Card>
+              <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
+                Feedback (optional)
+              </h2>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                If you would like to tell us why you are leaving, we read every message. This is sent
+                only to the site team, not displayed publicly.
+              </p>
+              <Textarea
+                value={feedback}
+                onChange={(e) => setFeedback(e.target.value)}
+                rows={4}
+                placeholder="Optional comments…"
+              />
+            </Card>
+
+            <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-between">
+              <Button
+                variant="danger"
+                onClick={() => setConfirmOpen(true)}
+                disabled={executeBusy}
+              >
+                Permanently delete my account
+              </Button>
+              <Link
+                to="/preferences"
+                className="text-sm text-trig-green-600 dark:text-trig-green-400 hover:underline"
+              >
+                Back to preferences
+              </Link>
+            </div>
+          </>
+        )}
+      </div>
+
+      <AlertDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Are you sure?"
+        description={confirmDescription}
+        cancelText="Cancel"
+        confirmText="Yes, proceed"
+        variant="danger"
+        onConfirm={() => {
+          void runExecute();
+        }}
+        confirmDisabled={executeBusy}
+      />
+    </>
+  );
+}

--- a/web/src/routes/Admin.tsx
+++ b/web/src/routes/Admin.tsx
@@ -772,6 +772,144 @@ function LogsNeedsAttentionCard({ getAccessTokenSilently }: LogsNeedsAttentionCa
   );
 }
 
+interface DeleteAccountAdminCardProps {
+  getAccessTokenSilently: GetAccessTokenSilently;
+}
+
+function DeleteAccountAdminCard({ getAccessTokenSilently }: DeleteAccountAdminCardProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<AdminUserSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const searchTimeoutRef = useRef<number | null>(null);
+  const searchRequestRef = useRef(0);
+  const searchInputId = useId();
+  const selectId = useId();
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (searchTimeoutRef.current !== null) {
+      window.clearTimeout(searchTimeoutRef.current);
+      searchTimeoutRef.current = null;
+    }
+    if (trimmed.length < 2) {
+      setResults([]);
+      setIsSearching(false);
+      return;
+    }
+    setIsSearching(true);
+    const currentRequest = searchRequestRef.current + 1;
+    searchRequestRef.current = currentRequest;
+    searchTimeoutRef.current = window.setTimeout(() => {
+      (async () => {
+        try {
+          const token = await getAccessTokenSilently({
+            authorizationParams: { ...ADMIN_AUTH_PARAMS },
+          });
+          const data = await searchLegacyUsers(trimmed, token);
+          if (searchRequestRef.current !== currentRequest) {
+            return;
+          }
+          setResults(data.items);
+          setError(null);
+        } catch (e) {
+          if (searchRequestRef.current !== currentRequest) {
+            return;
+          }
+          setResults([]);
+          setError(e instanceof Error ? e.message : "Failed to search users");
+        } finally {
+          if (searchRequestRef.current === currentRequest) {
+            setIsSearching(false);
+          }
+        }
+      })();
+    }, 300);
+    return () => {
+      if (searchTimeoutRef.current !== null) {
+        window.clearTimeout(searchTimeoutRef.current);
+        searchTimeoutRef.current = null;
+      }
+    };
+  }, [getAccessTokenSilently, query]);
+
+  return (
+    <Card className="mb-6">
+      <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-2">
+        Delete member account
+      </h2>
+      <p className="text-gray-600 dark:text-gray-400 text-sm mb-4">
+        Search by username or email fragment, select a member, then open the guided deletion page
+        (same flow as self-service, with administrator actions).
+      </p>
+      <div className="space-y-4 max-w-xl">
+        <div>
+          <label htmlFor={searchInputId} className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Search users
+          </label>
+          <input
+            id={searchInputId}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Start typing username or email…"
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-gray-800 dark:text-gray-100 bg-white dark:bg-gray-700 shadow-sm focus:border-trig-green-500 focus:ring-2 focus:ring-trig-green-400 dark:placeholder-gray-400"
+          />
+          {isSearching && (
+            <div className="flex items-center gap-2 mt-2">
+              <Spinner size="sm" />
+              <span className="text-sm text-gray-500 dark:text-gray-400">Searching…</span>
+            </div>
+          )}
+        </div>
+        <div>
+          <label htmlFor={selectId} className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Select user
+          </label>
+          <select
+            id={selectId}
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-gray-800 dark:text-gray-100 bg-white dark:bg-gray-700 shadow-sm focus:border-trig-green-500 focus:ring-2 focus:ring-trig-green-400 disabled:bg-gray-100 dark:disabled:bg-gray-600"
+            value={selectedUserId ?? ""}
+            onChange={(e) => setSelectedUserId(e.target.value ? Number(e.target.value) : null)}
+            disabled={results.length === 0}
+          >
+            <option value="">Choose a user…</option>
+            {results.map((u) => (
+              <option key={u.id} value={u.id}>
+                {`${u.name} — ${u.email || "no email"} — ID: ${u.id}`}
+              </option>
+            ))}
+          </select>
+        </div>
+        {error && (
+          <div className="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/30 px-3 py-2 text-sm text-red-700 dark:text-red-400">
+            {error}
+          </div>
+        )}
+        <div>
+          <a
+            href={selectedUserId ? `/account/delete?userId=${selectedUserId}` : "#"}
+            aria-disabled={!selectedUserId}
+            className={
+              selectedUserId
+                ? "inline-block bg-trig-green-600 hover:bg-trig-green-700 text-white font-medium px-4 py-2 rounded-md transition-colors"
+                : "inline-block bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 font-medium px-4 py-2 rounded-md cursor-not-allowed pointer-events-none"
+            }
+            onClick={(e) => {
+              if (!selectedUserId) {
+                e.preventDefault();
+              }
+            }}
+          >
+            Open account deletion page →
+          </a>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
 interface MergeUsersCardProps {
   getAccessTokenSilently: GetAccessTokenSilently;
 }
@@ -1475,6 +1613,8 @@ export default function Admin() {
         <MergeUsersCard getAccessTokenSilently={getAccessTokenSilently} />
 
         <LegacyMigrationCard getAccessTokenSilently={getAccessTokenSilently} />
+
+        <DeleteAccountAdminCard getAccessTokenSilently={getAccessTokenSilently} />
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <Card>

--- a/web/src/routes/Preferences.tsx
+++ b/web/src/routes/Preferences.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAuth0 } from "@auth0/auth0-react";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import toast from "react-hot-toast";
 import Card from "../components/ui/Card";
 import Spinner from "../components/ui/Spinner";
@@ -471,6 +471,24 @@ export default function Preferences() {
 
         {isAuthenticated && user && (
           <ArchivePreferencesPanel user={user} hasAdminRole={hasAdminRole} />
+        )}
+
+        {isAuthenticated && user && (
+          <Card className="border-red-200 dark:border-red-900/60">
+            <h2 className="text-lg font-semibold text-red-800 dark:text-red-300 mb-2">
+              Delete account
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+              Remove or anonymise your account and choose whether your logs and photos stay on the
+              site. You can download a backup first.
+            </p>
+            <Link
+              to="/account/delete"
+              className="inline-flex items-center justify-center rounded-md bg-red-800 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+            >
+              Delete account…
+            </Link>
+          </Card>
         )}
       </div>
     </>


### PR DESCRIPTION
Expose summary (including full name), email-backup, and execute flows for members and admins; wire Preferences and Admin UI, deletion service (Auth0, S3, anonymise/purge modes), and integration tests. Document manual archive job and note release.

Made-with: Cursor